### PR TITLE
LibAudio: Utility functions

### DIFF
--- a/Userland/Libraries/LibAudio/Sample.h
+++ b/Userland/Libraries/LibAudio/Sample.h
@@ -12,12 +12,48 @@
 
 namespace Audio {
 using namespace AK::Exponentials;
-// Constants for logarithmic volume. See Sample::linear_to_log
-// Corresponds to 60dB
+
+// Logarithmic scaling, as audio should ALWAYS do.
+// Reference: https://www.dr-lex.be/info-stuff/volumecontrols.html
+// We use the curve `factor = a * exp(b * change)`,
+// where change is the input fraction we want to change by,
+// a = 1/1000, b = ln(1000) = 6.908 and factor is the multiplier used.
+// The value 1000 represents the dynamic range in sound pressure, which corresponds to 60 dB(A).
+// This is a good dynamic range because it can represent all loudness values from
+// 30 dB(A) (barely hearable with background noise)
+// to 90 dB(A) (almost too loud to hear and about the reasonable limit of actual sound equipment).
+//
+// Format ranges:
+// - Linear:        0.0 to 1.0
+// - Logarithmic:   0.0 to 1.0
+// - dB:          -60.0 to 0.0
+
 constexpr double DYNAMIC_RANGE = 1000;
 constexpr double DYNAMIC_RANGE_DB = 60;
 constexpr double VOLUME_A = 1 / DYNAMIC_RANGE;
 double const VOLUME_B = log(DYNAMIC_RANGE);
+
+ALWAYS_INLINE double linear_to_log(double const change)
+{
+    // TODO: Add linear slope around 0
+    return VOLUME_A * exp(VOLUME_B * change);
+}
+
+ALWAYS_INLINE double log_to_linear(double const val)
+{
+    // TODO: Add linear slope around 0
+    return log(val / VOLUME_A) / VOLUME_B;
+}
+
+ALWAYS_INLINE double db_to_linear(double const dB)
+{
+    return (dB + DYNAMIC_RANGE_DB) / DYNAMIC_RANGE_DB;
+}
+
+ALWAYS_INLINE double linear_to_db(double const val)
+{
+    return val * DYNAMIC_RANGE_DB - DYNAMIC_RANGE_DB;
+}
 
 // A single sample in an audio buffer.
 // Values are floating point, and should range from -1.0 to +1.0
@@ -49,43 +85,6 @@ struct Sample {
             right = 1;
         else if (right < -1)
             right = -1;
-    }
-
-    // Logarithmic scaling, as audio should ALWAYS do.
-    // Reference: https://www.dr-lex.be/info-stuff/volumecontrols.html
-    // We use the curve `factor = a * exp(b * change)`,
-    // where change is the input fraction we want to change by,
-    // a = 1/1000, b = ln(1000) = 6.908 and factor is the multiplier used.
-    // The value 1000 represents the dynamic range in sound pressure, which corresponds to 60 dB(A).
-    // This is a good dynamic range because it can represent all loudness values from
-    // 30 dB(A) (barely hearable with background noise)
-    // to 90 dB(A) (almost too loud to hear and about the reasonable limit of actual sound equipment).
-    //
-    // Format ranges:
-    // - Linear:        0.0 to 1.0
-    // - Logarithmic:   0.0 to 1.0
-    // - dB:          -60.0 to 0.0
-
-    ALWAYS_INLINE double linear_to_log(double const change)
-    {
-        // TODO: Add linear slope around 0
-        return VOLUME_A * exp(VOLUME_B * change);
-    }
-
-    ALWAYS_INLINE double log_to_linear(double const val)
-    {
-        // TODO: Add linear slope around 0
-        return log(val / VOLUME_A) / VOLUME_B;
-    }
-
-    ALWAYS_INLINE double db_to_linear(double const dB)
-    {
-        return (dB + DYNAMIC_RANGE_DB) / DYNAMIC_RANGE_DB;
-    }
-
-    ALWAYS_INLINE double linear_to_db(double const val)
-    {
-        return val * DYNAMIC_RANGE_DB - DYNAMIC_RANGE_DB;
     }
 
     ALWAYS_INLINE Sample& log_multiply(double const change)

--- a/Userland/Libraries/LibAudio/Sample.h
+++ b/Userland/Libraries/LibAudio/Sample.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <AK/Math.h>
+#include <math.h>
 
 namespace Audio {
 using namespace AK::Exponentials;
@@ -67,12 +68,18 @@ ALWAYS_INLINE constexpr double amplitude_to_linear(double const amplitude)
 
 ALWAYS_INLINE double db_to_linear(double const dB)
 {
+    if (dB < -DYNAMIC_RANGE_DB)
+        return 0;
+
     return (dB + DYNAMIC_RANGE_DB) / DYNAMIC_RANGE_DB;
 }
 
-ALWAYS_INLINE double linear_to_db(double const val)
+ALWAYS_INLINE double linear_to_db(double const value)
 {
-    return val * DYNAMIC_RANGE_DB - DYNAMIC_RANGE_DB;
+    if (value == 0)
+        return -static_cast<double>(INFINITY);
+
+    return value * DYNAMIC_RANGE_DB - DYNAMIC_RANGE_DB;
 }
 
 // A single sample in an audio buffer.

--- a/Userland/Libraries/LibAudio/Sample.h
+++ b/Userland/Libraries/LibAudio/Sample.h
@@ -35,14 +35,16 @@ double const VOLUME_B = log(DYNAMIC_RANGE);
 
 ALWAYS_INLINE double linear_to_log(double const change)
 {
-    // TODO: Add linear slope around 0
-    return VOLUME_A * exp(VOLUME_B * change);
+    // Linear slope the first 3 dB to avoid asymptotic behaviour
+    // TODO: Can this be done more effectively?
+    return change < 0.05 ? change * 0.028 : VOLUME_A * exp(VOLUME_B * change);
 }
 
 ALWAYS_INLINE double log_to_linear(double const val)
 {
-    // TODO: Add linear slope around 0
-    return log(val / VOLUME_A) / VOLUME_B;
+    // Linear slope at val < 0.1 to avoid asymptotic behaviour
+    // TODO: Can this be done more effectively?
+    return val < 0.1 ? val * 50 : log(val / VOLUME_A) / VOLUME_B;
 }
 
 ALWAYS_INLINE double db_to_linear(double const dB)

--- a/Userland/Libraries/LibAudio/Sample.h
+++ b/Userland/Libraries/LibAudio/Sample.h
@@ -66,20 +66,20 @@ ALWAYS_INLINE constexpr double amplitude_to_linear(double const amplitude)
     return amplitude_to_linear_impl(amplitude);
 }
 
-ALWAYS_INLINE double db_to_linear(double const dB)
+ALWAYS_INLINE constexpr double db_to_linear(double const dB, double const dB_headroom = 0.0, double const dB_range = DYNAMIC_RANGE_DB)
 {
-    if (dB < -DYNAMIC_RANGE_DB)
+    if (dB < -dB_range)
         return 0;
 
-    return (dB + DYNAMIC_RANGE_DB) / DYNAMIC_RANGE_DB;
+    return (dB + dB_range - dB_headroom) / dB_range;
 }
 
-ALWAYS_INLINE double linear_to_db(double const value)
+ALWAYS_INLINE constexpr double linear_to_db(double const value, double const dB_headroom = 0.0, double const dB_range = DYNAMIC_RANGE_DB)
 {
     if (value == 0)
         return -static_cast<double>(INFINITY);
 
-    return value * DYNAMIC_RANGE_DB - DYNAMIC_RANGE_DB;
+    return value * dB_range - dB_range + dB_headroom;
 }
 
 // A single sample in an audio buffer.

--- a/Userland/Libraries/LibAudio/Sample.h
+++ b/Userland/Libraries/LibAudio/Sample.h
@@ -84,6 +84,17 @@ ALWAYS_INLINE constexpr double linear_to_db(double const value, double const dB_
     return value * dB_range - dB_range + dB_headroom;
 }
 
+// db <-> amplitude can be used for audio visualizations
+ALWAYS_INLINE constexpr double db_to_amplitude(double const dB)
+{
+    return AK::pow(10.0, 0.05 * dB);
+}
+
+ALWAYS_INLINE constexpr double amplitude_to_db(double const amplitude)
+{
+    return 20.0 * log10(amplitude);
+}
+
 // A single sample in an audio buffer.
 // Values are floating point, and should range from -1.0 to +1.0
 struct Sample {

--- a/Userland/Libraries/LibAudio/Sample.h
+++ b/Userland/Libraries/LibAudio/Sample.h
@@ -26,31 +26,43 @@ constexpr double BIT_DEPTH = 16;
 constexpr double DYNAMIC_RANGE_DB = 20.0 * log10(AK::pow(2.0, BIT_DEPTH));
 constexpr double DYNAMIC_RANGE = AK::pow(10.0, DYNAMIC_RANGE_DB * 0.05);
 constexpr double VOLUME_A = 1 / DYNAMIC_RANGE;
-double const VOLUME_B = log(DYNAMIC_RANGE);
+constexpr double VOLUME_B = log(DYNAMIC_RANGE);
 
 // Format ranges:
 // - Linear:        0.0 to 1.0
 // - Logarithmic:   0.0 to 1.0
 // - dB:         ~-96.3 to 0.0
 
-ALWAYS_INLINE double linear_to_amplitude(double const value)
+ALWAYS_INLINE constexpr double linear_to_amplitude_impl(double const value)
 {
-    // Linear slope at the lower values to avoid asymptotic behaviour
-    // NOTE: These values are dependent on the dynamic range and thus the bit depth.
-    if (value < 0.05)
-        return value * 0.028;
-
     return VOLUME_A * exp(VOLUME_B * value);
 }
 
-ALWAYS_INLINE double amplitude_to_linear(double const amplitude)
+ALWAYS_INLINE constexpr double amplitude_to_linear_impl(double const amplitude)
 {
-    // Linear slope at the lower values to avoid asymptotic behaviour
-    // NOTE: These values are dependent on the dynamic range and thus the bit depth.
-    if (amplitude < 0.1)
-        return amplitude * 50;
-
     return log(amplitude / VOLUME_A) / VOLUME_B;
+}
+
+// Since the functions to calculate linear values to amplitude and vice versais are logarithmic
+// we add a linear slope at the lower values to avoid asymptotic behaviour.
+// These constants define where we start that slope.
+constexpr double LINEAR_FALLOFF_THRESHOLD = 0.1;
+constexpr double LINEAR_FALLOFF_SLOPE = linear_to_amplitude_impl(LINEAR_FALLOFF_THRESHOLD) / LINEAR_FALLOFF_THRESHOLD;
+
+ALWAYS_INLINE constexpr double linear_to_amplitude(double const value)
+{
+    if (value < LINEAR_FALLOFF_THRESHOLD)
+        return value * LINEAR_FALLOFF_SLOPE;
+
+    return linear_to_amplitude_impl(value);
+}
+
+ALWAYS_INLINE constexpr double amplitude_to_linear(double const amplitude)
+{
+    if (amplitude < LINEAR_FALLOFF_THRESHOLD)
+        return amplitude / LINEAR_FALLOFF_SLOPE;
+
+    return amplitude_to_linear_impl(amplitude);
 }
 
 ALWAYS_INLINE double db_to_linear(double const dB)

--- a/Userland/Libraries/LibAudio/Sample.h
+++ b/Userland/Libraries/LibAudio/Sample.h
@@ -17,21 +17,21 @@ using namespace AK::Exponentials;
 // Reference: https://www.dr-lex.be/info-stuff/volumecontrols.html
 // We use the curve `factor = a * exp(b * change)`,
 // where change is the input fraction we want to change by,
-// a = 1/1000, b = ln(1000) = 6.908 and factor is the multiplier used.
-// The value 1000 represents the dynamic range in sound pressure, which corresponds to 60 dB(A).
-// This is a good dynamic range because it can represent all loudness values from
-// 30 dB(A) (barely hearable with background noise)
-// to 90 dB(A) (almost too loud to hear and about the reasonable limit of actual sound equipment).
-//
+// The dynamic range is based on the bit depth which is currently set to
+// 16 bit. This might change in the future and can be changed later.
+// This dynamic range gives us ~96.3 dB of dB range.
+// Reference: https://en.wikipedia.org/wiki/DBFS
+
+constexpr double BIT_DEPTH = 16;
+constexpr double DYNAMIC_RANGE_DB = 20.0 * log10(AK::pow(2.0, BIT_DEPTH));
+constexpr double DYNAMIC_RANGE = AK::pow(10.0, DYNAMIC_RANGE_DB * 0.05);
+constexpr double VOLUME_A = 1 / DYNAMIC_RANGE;
+double const VOLUME_B = log(DYNAMIC_RANGE);
+
 // Format ranges:
 // - Linear:        0.0 to 1.0
 // - Logarithmic:   0.0 to 1.0
-// - dB:          -60.0 to 0.0
-
-constexpr double DYNAMIC_RANGE = 1000;
-constexpr double DYNAMIC_RANGE_DB = 60;
-constexpr double VOLUME_A = 1 / DYNAMIC_RANGE;
-double const VOLUME_B = log(DYNAMIC_RANGE);
+// - dB:         ~-96.3 to 0.0
 
 ALWAYS_INLINE double linear_to_log(double const change)
 {

--- a/Userland/Libraries/LibDSP/Effects.cpp
+++ b/Userland/Libraries/LibDSP/Effects.cpp
@@ -71,7 +71,7 @@ Signal Mastering::process_impl(Signal const& input_signal)
         return Signal(out);
     }
 
-    out += in.log_pan(static_cast<double>(m_pan));
+    out += in.panned(static_cast<double>(m_pan));
     out += in.log_multiplied(static_cast<double>(m_master_volume));
     return Signal(out);
 }


### PR DESCRIPTION
- Adds utility functions such as:
  - Linear to/from amplitute (i.e. logarithmic audio signal)
  - Linear to/from dB based on the bitrate
  - Amplitude to/from dB
- Replace old panning with constant power panning
- Use the full 16 bit dynamic range