### PR TITLE
Spreadsheet: Migrate to String

### DIFF
--- a/AK/String.h
+++ b/AK/String.h
@@ -69,6 +69,7 @@ public:
     template<typename T>
     requires(IsOneOf<RemoveCVReference<T>, DeprecatedString, DeprecatedFlyString>)
     static ErrorOr<String> from_utf8(T&&) = delete;
+    static ErrorOr<String> from_view(Utf8View view);
 
     // Creates a new String by reading byte_count bytes from a UTF-8 encoded Stream.
     static ErrorOr<String> from_stream(Stream&, size_t byte_count);

--- a/Userland/Applications/Spreadsheet/Cell.cpp
+++ b/Userland/Applications/Spreadsheet/Cell.cpp
@@ -12,7 +12,7 @@
 
 namespace Spreadsheet {
 
-void Cell::set_data(DeprecatedString new_data)
+void Cell::set_data(String new_data)
 {
     // If we are a formula, we do not save the beginning '=', if the new_data is "" we can simply change our kind
     if (m_kind == Formula && m_data.is_empty() && new_data.is_empty()) {
@@ -24,7 +24,7 @@ void Cell::set_data(DeprecatedString new_data)
         return;
 
     if (new_data.starts_with('=')) {
-        new_data = new_data.substring(1, new_data.length() - 1);
+        new_data = MUST(String::from_view(new_data.code_points().unicode_substring_view(1)));
         m_kind = Formula;
     } else {
         m_kind = LiteralString;
@@ -43,7 +43,7 @@ void Cell::set_data(JS::Value new_data)
     StringBuilder builder;
 
     builder.append(new_data.to_string_without_side_effects());
-    m_data = builder.to_deprecated_string();
+    m_data = MUST(builder.to_string());
 
     m_evaluated_data = move(new_data);
 }
@@ -79,14 +79,14 @@ CellType const& Cell::type() const
         return *m_type;
 
     if (m_kind == LiteralString) {
-        if (m_data.to_int().has_value())
+        if (m_data.bytes_as_string_view().to_int().has_value())
             return *CellType::get_by_name("Numeric"sv);
     }
 
     return *CellType::get_by_name("Identity"sv);
 }
 
-JS::ThrowCompletionOr<DeprecatedString> Cell::typed_display() const
+JS::ThrowCompletionOr<String> Cell::typed_display() const
 {
     return type().display(const_cast<Cell&>(*this), m_type_metadata);
 }
@@ -163,13 +163,13 @@ JS::Value Cell::js_data()
     return JS::PrimitiveString::create(vm, m_data);
 }
 
-DeprecatedString Cell::source() const
+String Cell::source() const
 {
     StringBuilder builder;
     if (m_kind == Formula)
         builder.append('=');
     builder.append(m_data);
-    return builder.to_deprecated_string();
+    return MUST(builder.to_string());
 }
 
 // FIXME: Find a better way to figure out dependencies

--- a/Userland/Applications/Spreadsheet/Cell.h
+++ b/Userland/Applications/Spreadsheet/Cell.h
@@ -11,7 +11,7 @@
 #include "Forward.h"
 #include "JSIntegration.h"
 #include "Position.h"
-#include <AK/DeprecatedString.h>
+#include <AK/String.h>
 #include <AK/Types.h>
 #include <AK/WeakPtr.h>
 #include <LibGUI/Command.h>
@@ -24,7 +24,7 @@ struct Cell : public Weakable<Cell> {
         Formula,
     };
 
-    Cell(DeprecatedString data, Position position, WeakPtr<Sheet> sheet)
+    Cell(String data, Position position, WeakPtr<Sheet> sheet)
         : m_dirty(false)
         , m_data(move(data))
         , m_kind(LiteralString)
@@ -33,7 +33,7 @@ struct Cell : public Weakable<Cell> {
     {
     }
 
-    Cell(DeprecatedString source, JS::Value&& cell_value, Position position, WeakPtr<Sheet> sheet)
+    Cell(String source, JS::Value&& cell_value, Position position, WeakPtr<Sheet> sheet)
         : m_dirty(false)
         , m_data(move(source))
         , m_evaluated_data(move(cell_value))
@@ -45,7 +45,7 @@ struct Cell : public Weakable<Cell> {
 
     void reference_from(Cell*);
 
-    void set_data(DeprecatedString new_data);
+    void set_data(String new_data);
     void set_data(JS::Value new_data);
     bool dirty() const { return m_dirty; }
     void clear_dirty() { m_dirty = false; }
@@ -55,7 +55,7 @@ struct Cell : public Weakable<Cell> {
         if (!m_name_for_javascript.is_empty())
             return m_name_for_javascript;
 
-        m_name_for_javascript = DeprecatedString::formatted("cell {}", m_position.to_cell_identifier(sheet));
+        m_name_for_javascript = MUST(String::formatted("cell {}", m_position.to_cell_identifier(sheet)));
         return m_name_for_javascript;
     }
 
@@ -67,7 +67,7 @@ struct Cell : public Weakable<Cell> {
         return m_thrown_value;
     }
 
-    DeprecatedString const& data() const { return m_data; }
+    String const& data() const { return m_data; }
     const JS::Value& evaluated_data() const { return m_evaluated_data; }
     Kind kind() const { return m_kind; }
     Vector<WeakPtr<Cell>> const& referencing_cells() const { return m_referencing_cells; }
@@ -95,14 +95,14 @@ struct Cell : public Weakable<Cell> {
         m_conditional_formats = move(fmts);
     }
 
-    JS::ThrowCompletionOr<DeprecatedString> typed_display() const;
+    JS::ThrowCompletionOr<String> typed_display() const;
     JS::ThrowCompletionOr<JS::Value> typed_js_data() const;
 
     CellType const& type() const;
     CellTypeMetadata const& type_metadata() const { return m_type_metadata; }
     CellTypeMetadata& type_metadata() { return m_type_metadata; }
 
-    DeprecatedString source() const;
+    String source() const;
 
     JS::Value js_data();
 
@@ -117,7 +117,7 @@ struct Cell : public Weakable<Cell> {
 private:
     bool m_dirty { false };
     bool m_evaluated_externally { false };
-    DeprecatedString m_data;
+    String m_data;
     JS::Value m_evaluated_data;
     JS::Value m_thrown_value;
     Kind m_kind { LiteralString };
@@ -126,7 +126,7 @@ private:
     CellType const* m_type { nullptr };
     CellTypeMetadata m_type_metadata;
     Position m_position;
-    mutable DeprecatedString m_name_for_javascript;
+    mutable String m_name_for_javascript;
 
     Vector<ConditionalFormat> m_conditional_formats;
     Format m_evaluated_formats;

--- a/Userland/Applications/Spreadsheet/CellType/Date.cpp
+++ b/Userland/Applications/Spreadsheet/CellType/Date.cpp
@@ -17,15 +17,15 @@ DateCell::DateCell()
 {
 }
 
-JS::ThrowCompletionOr<DeprecatedString> DateCell::display(Cell& cell, CellTypeMetadata const& metadata) const
+JS::ThrowCompletionOr<String> DateCell::display(Cell& cell, CellTypeMetadata const& metadata) const
 {
-    return propagate_failure(cell, [&]() -> JS::ThrowCompletionOr<DeprecatedString> {
+    return propagate_failure(cell, [&]() -> JS::ThrowCompletionOr<String> {
         auto& vm = cell.sheet().global_object().vm();
         auto timestamp = TRY(js_value(cell, metadata));
-        auto string = Core::DateTime::from_timestamp(TRY(timestamp.to_i32(vm))).to_deprecated_string(metadata.format.is_empty() ? "%Y-%m-%d %H:%M:%S"sv : metadata.format.view());
+        auto string = MUST(Core::DateTime::from_timestamp(TRY(timestamp.to_i32(vm))).to_string(metadata.format.is_empty() ? "%Y-%m-%d %H:%M:%S"sv : metadata.format.bytes_as_string_view()));
 
         if (metadata.length >= 0)
-            return string.substring(0, metadata.length);
+            return MUST(String::from_view(string.code_points().unicode_substring_view(0, min(string.code_points().length(), metadata.length))));
 
         return string;
     });

--- a/Userland/Applications/Spreadsheet/CellType/Date.h
+++ b/Userland/Applications/Spreadsheet/CellType/Date.h
@@ -16,7 +16,7 @@ class DateCell : public CellType {
 public:
     DateCell();
     virtual ~DateCell() override = default;
-    virtual JS::ThrowCompletionOr<DeprecatedString> display(Cell&, CellTypeMetadata const&) const override;
+    virtual JS::ThrowCompletionOr<String> display(Cell&, CellTypeMetadata const&) const override;
     virtual JS::ThrowCompletionOr<JS::Value> js_value(Cell&, CellTypeMetadata const&) const override;
     virtual String metadata_hint(MetadataName) const override;
 };

--- a/Userland/Applications/Spreadsheet/CellType/Format.cpp
+++ b/Userland/Applications/Spreadsheet/CellType/Format.cpp
@@ -5,8 +5,8 @@
  */
 
 #include "Format.h"
-#include <AK/DeprecatedString.h>
 #include <AK/PrintfImplementation.h>
+#include <AK/String.h>
 #include <AK/StringBuilder.h>
 
 namespace Spreadsheet {
@@ -37,13 +37,13 @@ struct PrintfImpl : public PrintfImplementation::PrintfImpl<PutChFunc, ArgumentL
     }
 };
 
-DeprecatedString format_double(char const* format, double value)
+String format_double(char const* format, double value)
 {
     StringBuilder builder;
     auto putch = [&](auto, auto ch) { builder.append(ch); };
     printf_internal<decltype(putch), PrintfImpl, double, SingleEntryListNext>(putch, nullptr, format, value);
 
-    return builder.to_deprecated_string();
+    return MUST(builder.to_string());
 }
 
 }

--- a/Userland/Applications/Spreadsheet/CellType/Format.h
+++ b/Userland/Applications/Spreadsheet/CellType/Format.h
@@ -10,6 +10,6 @@
 
 namespace Spreadsheet {
 
-DeprecatedString format_double(char const* format, double value);
+String format_double(char const* format, double value);
 
 }

--- a/Userland/Applications/Spreadsheet/CellType/Identity.cpp
+++ b/Userland/Applications/Spreadsheet/CellType/Identity.cpp
@@ -15,14 +15,14 @@ IdentityCell::IdentityCell()
 {
 }
 
-JS::ThrowCompletionOr<DeprecatedString> IdentityCell::display(Cell& cell, CellTypeMetadata const& metadata) const
+JS::ThrowCompletionOr<String> IdentityCell::display(Cell& cell, CellTypeMetadata const& metadata) const
 {
     auto& vm = cell.sheet().global_object().vm();
     auto data = cell.js_data();
     if (!metadata.format.is_empty())
         data = TRY(cell.sheet().evaluate(metadata.format, &cell));
 
-    return data.to_deprecated_string(vm);
+    return data.to_string(vm);
 }
 
 JS::ThrowCompletionOr<JS::Value> IdentityCell::js_value(Cell& cell, CellTypeMetadata const&) const

--- a/Userland/Applications/Spreadsheet/CellType/Identity.h
+++ b/Userland/Applications/Spreadsheet/CellType/Identity.h
@@ -15,7 +15,7 @@ class IdentityCell : public CellType {
 public:
     IdentityCell();
     virtual ~IdentityCell() override = default;
-    virtual JS::ThrowCompletionOr<DeprecatedString> display(Cell&, CellTypeMetadata const&) const override;
+    virtual JS::ThrowCompletionOr<String> display(Cell&, CellTypeMetadata const&) const override;
     virtual JS::ThrowCompletionOr<JS::Value> js_value(Cell&, CellTypeMetadata const&) const override;
     virtual String metadata_hint(MetadataName) const override;
 };

--- a/Userland/Applications/Spreadsheet/CellType/Numeric.cpp
+++ b/Userland/Applications/Spreadsheet/CellType/Numeric.cpp
@@ -18,19 +18,21 @@ NumericCell::NumericCell()
 {
 }
 
-JS::ThrowCompletionOr<DeprecatedString> NumericCell::display(Cell& cell, CellTypeMetadata const& metadata) const
+JS::ThrowCompletionOr<String> NumericCell::display(Cell& cell, CellTypeMetadata const& metadata) const
 {
-    return propagate_failure(cell, [&]() -> JS::ThrowCompletionOr<DeprecatedString> {
+    return propagate_failure(cell, [&]() -> JS::ThrowCompletionOr<String> {
         auto& vm = cell.sheet().global_object().vm();
         auto value = TRY(js_value(cell, metadata));
-        DeprecatedString string;
+        String string;
         if (metadata.format.is_empty())
-            string = TRY(value.to_deprecated_string(vm));
-        else
-            string = format_double(metadata.format.characters(), TRY(value.to_double(vm)));
+            string = TRY(value.to_string(vm));
+        else {
+            auto format = MUST(String::formatted("{}\0", metadata.format));
+            string = format_double(format.bytes_as_string_view().characters_without_null_termination(), TRY(value.to_double(vm)));
+        }
 
         if (metadata.length >= 0)
-            return string.substring(0, min(string.length(), metadata.length));
+            return MUST(String::from_view(string.code_points().unicode_substring_view(0, min(string.code_points().length(), metadata.length))));
 
         return string;
     });

--- a/Userland/Applications/Spreadsheet/CellType/Numeric.h
+++ b/Userland/Applications/Spreadsheet/CellType/Numeric.h
@@ -26,7 +26,7 @@ class NumericCell : public CellType {
 public:
     NumericCell();
     virtual ~NumericCell() override = default;
-    virtual JS::ThrowCompletionOr<DeprecatedString> display(Cell&, CellTypeMetadata const&) const override;
+    virtual JS::ThrowCompletionOr<String> display(Cell&, CellTypeMetadata const&) const override;
     virtual JS::ThrowCompletionOr<JS::Value> js_value(Cell&, CellTypeMetadata const&) const override;
     virtual String metadata_hint(MetadataName) const override;
 };

--- a/Userland/Applications/Spreadsheet/CellType/String.cpp
+++ b/Userland/Applications/Spreadsheet/CellType/String.cpp
@@ -7,6 +7,7 @@
 #include "String.h"
 #include "../Cell.h"
 #include "../Spreadsheet.h"
+#include <LibJS/Runtime/Completion.h>
 
 namespace Spreadsheet {
 
@@ -15,12 +16,12 @@ StringCell::StringCell()
 {
 }
 
-JS::ThrowCompletionOr<DeprecatedString> StringCell::display(Cell& cell, CellTypeMetadata const& metadata) const
+JS::ThrowCompletionOr<String> StringCell::display(Cell& cell, CellTypeMetadata const& metadata) const
 {
     auto& vm = cell.sheet().global_object().vm();
-    auto string = TRY(cell.js_data().to_deprecated_string(vm));
+    auto string = TRY(cell.js_data().to_string(vm));
     if (metadata.length >= 0)
-        return string.substring(0, metadata.length);
+        return MUST(String::from_view(string.code_points().unicode_substring_view(0, metadata.length)));
 
     return string;
 }

--- a/Userland/Applications/Spreadsheet/CellType/String.h
+++ b/Userland/Applications/Spreadsheet/CellType/String.h
@@ -15,7 +15,7 @@ class StringCell : public CellType {
 public:
     StringCell();
     virtual ~StringCell() override = default;
-    virtual JS::ThrowCompletionOr<DeprecatedString> display(Cell&, CellTypeMetadata const&) const override;
+    virtual JS::ThrowCompletionOr<String> display(Cell&, CellTypeMetadata const&) const override;
     virtual JS::ThrowCompletionOr<JS::Value> js_value(Cell&, CellTypeMetadata const&) const override;
     virtual String metadata_hint(MetadataName) const override;
 };

--- a/Userland/Applications/Spreadsheet/CellType/Type.cpp
+++ b/Userland/Applications/Spreadsheet/CellType/Type.cpp
@@ -12,7 +12,7 @@
 #include <AK/HashMap.h>
 #include <AK/OwnPtr.h>
 
-static HashMap<DeprecatedString, Spreadsheet::CellType*> s_cell_types;
+static HashMap<String, Spreadsheet::CellType*> s_cell_types;
 static Spreadsheet::StringCell s_string_cell;
 static Spreadsheet::NumericCell s_numeric_cell;
 static Spreadsheet::IdentityCell s_identity_cell;
@@ -34,10 +34,10 @@ Vector<StringView> CellType::names()
 }
 
 CellType::CellType(StringView name)
-    : m_name(name)
+    : m_name(MUST(String::from_utf8(name)))
 {
     VERIFY(!s_cell_types.contains(name));
-    s_cell_types.set(name, this);
+    s_cell_types.set(m_name, this);
 }
 
 }

--- a/Userland/Applications/Spreadsheet/CellType/Type.h
+++ b/Userland/Applications/Spreadsheet/CellType/Type.h
@@ -8,8 +8,8 @@
 
 #include "../ConditionalFormatting.h"
 #include "../Forward.h"
-#include <AK/DeprecatedString.h>
 #include <AK/Forward.h>
+#include <AK/String.h>
 #include <LibGfx/Color.h>
 #include <LibGfx/TextAlignment.h>
 #include <LibJS/Forward.h>
@@ -18,7 +18,7 @@ namespace Spreadsheet {
 
 struct CellTypeMetadata {
     int length { -1 };
-    DeprecatedString format;
+    String format;
     Gfx::TextAlignment alignment { Gfx::TextAlignment::CenterRight };
     Format static_format;
 };
@@ -35,18 +35,18 @@ public:
     static CellType const* get_by_name(StringView);
     static Vector<StringView> names();
 
-    virtual JS::ThrowCompletionOr<DeprecatedString> display(Cell&, CellTypeMetadata const&) const = 0;
+    virtual JS::ThrowCompletionOr<String> display(Cell&, CellTypeMetadata const&) const = 0;
     virtual JS::ThrowCompletionOr<JS::Value> js_value(Cell&, CellTypeMetadata const&) const = 0;
     virtual String metadata_hint(MetadataName) const { return {}; }
     virtual ~CellType() = default;
 
-    DeprecatedString const& name() const { return m_name; }
+    String const& name() const { return m_name; }
 
 protected:
     CellType(StringView name);
 
 private:
-    DeprecatedString m_name;
+    String m_name;
 };
 
 }

--- a/Userland/Applications/Spreadsheet/CellTypeDialog.cpp
+++ b/Userland/Applications/Spreadsheet/CellTypeDialog.cpp
@@ -61,9 +61,9 @@ CellTypeDialog::CellTypeDialog(Vector<Position> const& positions, Sheet& sheet, 
     ok_button.on_click = [&](auto) { done(ExecResult::OK); };
 }
 
-Vector<DeprecatedString> const g_horizontal_alignments { "Left", "Center", "Right" };
-Vector<DeprecatedString> const g_vertical_alignments { "Top", "Center", "Bottom" };
-Vector<DeprecatedString> g_types;
+Vector<String> const g_horizontal_alignments { "Left"_string, "Center"_string, "Right"_string };
+Vector<String> const g_vertical_alignments { "Top"_string, "Center"_string, "Bottom"_string };
+Vector<String> g_types;
 
 constexpr static CellTypeDialog::VerticalAlignment vertical_alignment_from(Gfx::TextAlignment alignment)
 {
@@ -113,7 +113,7 @@ void CellTypeDialog::setup_tabs(GUI::TabWidget& tabs, Vector<Position> const& po
 {
     g_types.clear();
     for (auto& type_name : CellType::names())
-        g_types.append(type_name);
+        g_types.append(MUST(String::from_utf8(type_name)));
 
     Vector<Cell&> cells;
     for (auto& position : positions) {
@@ -142,7 +142,7 @@ void CellTypeDialog::setup_tabs(GUI::TabWidget& tabs, Vector<Position> const& po
         right_side.set_fixed_width(170);
 
         auto& type_list = left_side.add<GUI::ListView>();
-        type_list.set_model(*GUI::ItemListModel<DeprecatedString>::create(g_types));
+        type_list.set_model(*GUI::ItemListModel<String>::create(g_types));
         type_list.set_should_hide_unnecessary_scrollbars(true);
         type_list.on_selection_change = [&] {
             const auto& index = type_list.selection().first();
@@ -188,11 +188,11 @@ void CellTypeDialog::setup_tabs(GUI::TabWidget& tabs, Vector<Position> const& po
             checkbox.on_checked = [&](auto checked) {
                 editor.set_enabled(checked);
                 if (!checked)
-                    m_format = DeprecatedString::empty();
+                    m_format = {};
                 editor.set_text(m_format);
             };
             editor.on_change = [&] {
-                m_format = editor.text();
+                m_format = MUST(String::from_deprecated_string(editor.text()));
             };
         }
     }
@@ -213,7 +213,7 @@ void CellTypeDialog::setup_tabs(GUI::TabWidget& tabs, Vector<Position> const& po
 
             auto& horizontal_combobox = alignment_tab.add<GUI::ComboBox>();
             horizontal_combobox.set_only_allow_values_from_model(true);
-            horizontal_combobox.set_model(*GUI::ItemListModel<DeprecatedString>::create(g_horizontal_alignments));
+            horizontal_combobox.set_model(*GUI::ItemListModel<String>::create(g_horizontal_alignments));
             horizontal_combobox.set_selected_index((int)m_horizontal_alignment);
             horizontal_combobox.on_change = [&](auto&, const GUI::ModelIndex& index) {
                 switch (index.row()) {
@@ -244,7 +244,7 @@ void CellTypeDialog::setup_tabs(GUI::TabWidget& tabs, Vector<Position> const& po
 
             auto& vertical_combobox = alignment_tab.add<GUI::ComboBox>();
             vertical_combobox.set_only_allow_values_from_model(true);
-            vertical_combobox.set_model(*GUI::ItemListModel<DeprecatedString>::create(g_vertical_alignments));
+            vertical_combobox.set_model(*GUI::ItemListModel<String>::create(g_vertical_alignments));
             vertical_combobox.set_selected_index((int)m_vertical_alignment);
             vertical_combobox.on_change = [&](auto&, const GUI::ModelIndex& index) {
                 switch (index.row()) {
@@ -412,7 +412,7 @@ ConditionView::ConditionView(ConditionalFormat& fmt)
     formula_editor.set_syntax_highlighter(make<JS::SyntaxHighlighter>());
     formula_editor.set_should_hide_unnecessary_scrollbars(true);
     formula_editor.on_change = [&] {
-        m_format.condition = formula_editor.text();
+        m_format.condition = MUST(String::from_deprecated_string(formula_editor.text()));
     };
 }
 

--- a/Userland/Applications/Spreadsheet/CellTypeDialog.h
+++ b/Userland/Applications/Spreadsheet/CellTypeDialog.h
@@ -39,7 +39,7 @@ private:
     CellType const* m_type { nullptr };
 
     int m_length { -1 };
-    DeprecatedString m_format;
+    String m_format;
     HorizontalAlignment m_horizontal_alignment { HorizontalAlignment::Right };
     VerticalAlignment m_vertical_alignment { VerticalAlignment::Center };
     Format m_static_format;

--- a/Userland/Applications/Spreadsheet/ConditionalFormatting.h
+++ b/Userland/Applications/Spreadsheet/ConditionalFormatting.h
@@ -7,7 +7,7 @@
 #pragma once
 
 #include "Forward.h"
-#include <AK/DeprecatedString.h>
+#include <AK/String.h>
 #include <LibGUI/AbstractScrollableWidget.h>
 #include <LibGfx/Color.h>
 
@@ -19,7 +19,7 @@ struct Format {
 };
 
 struct ConditionalFormat : public Format {
-    DeprecatedString condition;
+    String condition;
 };
 
 enum class FormatType {

--- a/Userland/Applications/Spreadsheet/ExportDialog.cpp
+++ b/Userland/Applications/Spreadsheet/ExportDialog.cpp
@@ -7,10 +7,10 @@
 #include "ExportDialog.h"
 #include "Spreadsheet.h"
 #include "Workbook.h"
-#include <AK/DeprecatedString.h>
 #include <AK/JsonArray.h>
 #include <AK/LexicalPath.h>
 #include <AK/MemoryStream.h>
+#include <AK/String.h>
 #include <Applications/Spreadsheet/CSVExportGML.h>
 #include <LibCore/StandardPaths.h>
 #include <LibGUI/Application.h>
@@ -59,7 +59,7 @@ CSVExportDialogPage::CSVExportDialogPage(Sheet const& sheet)
 
     m_data_preview_text_editor->set_should_hide_unnecessary_scrollbars(true);
 
-    m_quote_escape_combo_box->set_model(GUI::ItemListModel<DeprecatedString>::create(m_quote_escape_items));
+    m_quote_escape_combo_box->set_model(GUI::ItemListModel<String>::create(m_quote_escape_items));
 
     // By default, use commas, double quotes with repeat, disable headers, and quote only the fields that require quoting.
     m_delimiter_comma_radio->set_checked(true);
@@ -91,33 +91,33 @@ CSVExportDialogPage::CSVExportDialogPage(Sheet const& sheet)
 
 auto CSVExportDialogPage::generate(Stream& stream, GenerationType type) -> ErrorOr<void>
 {
-    auto delimiter = TRY([this]() -> ErrorOr<DeprecatedString> {
+    auto delimiter = TRY([this]() -> ErrorOr<String> {
         if (m_delimiter_other_radio->is_checked()) {
             if (m_delimiter_other_text_box->text().is_empty())
                 return Error::from_string_literal("Delimiter unset");
-            return m_delimiter_other_text_box->text();
+            return String::from_deprecated_string(m_delimiter_other_text_box->text());
         }
         if (m_delimiter_comma_radio->is_checked())
-            return ",";
+            return ","_string;
         if (m_delimiter_semicolon_radio->is_checked())
-            return ";";
+            return ";"_string;
         if (m_delimiter_tab_radio->is_checked())
-            return "\t";
+            return "\t"_string;
         if (m_delimiter_space_radio->is_checked())
-            return " ";
+            return " "_string;
         return Error::from_string_literal("Delimiter unset");
     }());
 
-    auto quote = TRY([this]() -> ErrorOr<DeprecatedString> {
+    auto quote = TRY([this]() -> ErrorOr<String> {
         if (m_quote_other_radio->is_checked()) {
             if (m_quote_other_text_box->text().is_empty())
                 return Error::from_string_literal("Quote separator unset");
-            return m_quote_other_text_box->text();
+            return String::from_deprecated_string(m_quote_other_text_box->text());
         }
         if (m_quote_single_radio->is_checked())
-            return "'";
+            return "'"_string;
         if (m_quote_double_radio->is_checked())
-            return "\"";
+            return "\""_string;
         return Error::from_string_literal("Quote separator unset");
     }());
 
@@ -140,7 +140,7 @@ auto CSVExportDialogPage::generate(Stream& stream, GenerationType type) -> Error
     };
 
     auto behaviors = Writer::default_behaviors();
-    Vector<DeprecatedString> empty_headers;
+    Vector<String> empty_headers;
     auto* headers = &empty_headers;
 
     if (should_export_headers) {
@@ -153,7 +153,7 @@ auto CSVExportDialogPage::generate(Stream& stream, GenerationType type) -> Error
 
     switch (type) {
     case GenerationType::Normal:
-        TRY((Writer::XSV<decltype(m_data), Vector<DeprecatedString>>::generate(stream, m_data, move(traits), *headers, behaviors)));
+        TRY((Writer::XSV<decltype(m_data), Vector<String>>::generate(stream, m_data, move(traits), *headers, behaviors)));
         break;
     case GenerationType::Preview:
         TRY((Writer::XSV<decltype(m_data), decltype(*headers)>::generate_preview(stream, m_data, move(traits), *headers, behaviors)));
@@ -176,10 +176,10 @@ void CSVExportDialogPage::update_preview()
         return {};
     }();
     if (maybe_error.is_error())
-        m_data_preview_text_editor->set_text(DeprecatedString::formatted("Cannot update preview: {}", maybe_error.error()));
+        m_data_preview_text_editor->set_text(MUST(String::formatted("Cannot update preview: {}", maybe_error.error())).bytes_as_string_view());
 }
 
-ErrorOr<void> ExportDialog::make_and_run_for(StringView mime, Core::File& file, DeprecatedString filename, Workbook& workbook)
+ErrorOr<void> ExportDialog::make_and_run_for(StringView mime, Core::File& file, String filename, Workbook& workbook)
 {
     auto wizard = TRY(GUI::WizardDialog::create(GUI::Application::the()->active_window()));
     wizard->set_title("File Export Wizard");
@@ -216,18 +216,18 @@ ErrorOr<void> ExportDialog::make_and_run_for(StringView mime, Core::File& file, 
     } else {
         auto page = TRY(GUI::WizardPage::create(
             "Export File Format"sv,
-            TRY(String::formatted("Select the format you wish to export to '{}' as", LexicalPath::basename(filename)))));
+            TRY(String::formatted("Select the format you wish to export to '{}' as", LexicalPath::basename(filename.bytes_as_string_view())))));
 
         page->on_next_page = [] { return nullptr; };
 
         TRY(page->body_widget().load_from_gml(select_format_page_gml));
         auto format_combo_box = page->body_widget().find_descendant_of_type_named<GUI::ComboBox>("select_format_page_format_combo_box");
 
-        Vector<DeprecatedString> supported_formats {
-            "CSV (text/csv)",
-            "Spreadsheet Worksheet",
+        Vector<String> supported_formats {
+            "CSV (text/csv)"_string,
+            "Spreadsheet Worksheet"_string,
         };
-        format_combo_box->set_model(GUI::ItemListModel<DeprecatedString>::create(supported_formats));
+        format_combo_box->set_model(GUI::ItemListModel<String>::create(supported_formats));
 
         wizard->push_page(page);
 

--- a/Userland/Applications/Spreadsheet/ExportDialog.h
+++ b/Userland/Applications/Spreadsheet/ExportDialog.h
@@ -33,8 +33,8 @@ protected:
     void update_preview();
 
 private:
-    Vector<Vector<DeprecatedString>> m_data;
-    Vector<DeprecatedString> m_headers;
+    Vector<Vector<String>> m_data;
+    Vector<String> m_headers;
     RefPtr<GUI::WizardPage> m_page;
     RefPtr<GUI::RadioButton> m_delimiter_comma_radio;
     RefPtr<GUI::RadioButton> m_delimiter_semicolon_radio;
@@ -50,15 +50,15 @@ private:
     RefPtr<GUI::CheckBox> m_export_header_check_box;
     RefPtr<GUI::CheckBox> m_quote_all_fields_check_box;
     RefPtr<GUI::TextEditor> m_data_preview_text_editor;
-    Vector<DeprecatedString> m_quote_escape_items {
+    Vector<String> m_quote_escape_items {
         // Note: Keep in sync with Writer::WriterTraits::QuoteEscape.
-        "Repeat",
-        "Backslash",
+        "Repeat"_string,
+        "Backslash"_string,
     };
 };
 
 struct ExportDialog {
-    static ErrorOr<void> make_and_run_for(StringView mime, Core::File&, DeprecatedString filename, Workbook&);
+    static ErrorOr<void> make_and_run_for(StringView mime, Core::File&, String filename, Workbook&);
 };
 
 }

--- a/Userland/Applications/Spreadsheet/HelpWindow.cpp
+++ b/Userland/Applications/Spreadsheet/HelpWindow.cpp
@@ -38,13 +38,13 @@ public:
         return {};
     }
 
-    DeprecatedString key(const GUI::ModelIndex& index) const { return m_keys[index.row()]; }
+    String key(const GUI::ModelIndex& index) const { return m_keys[index.row()]; }
 
     void set_from(JsonObject const& object)
     {
         m_keys.clear();
         object.for_each_member([this](auto& name, auto&) {
-            m_keys.append(name);
+            m_keys.append(MUST(String::from_deprecated_string(name)));
         });
         AK::quick_sort(m_keys);
         invalidate();
@@ -55,7 +55,7 @@ private:
     {
     }
 
-    Vector<DeprecatedString> m_keys;
+    Vector<String> m_keys;
 };
 
 RefPtr<HelpWindow> HelpWindow::s_the { nullptr };
@@ -90,7 +90,7 @@ HelpWindow::HelpWindow(GUI::Window* parent)
             auto entry = LexicalPath::basename(example_path);
             auto doc_option = m_docs.get_object(entry);
             if (!doc_option.has_value()) {
-                GUI::MessageBox::show_error(this, DeprecatedString::formatted("No documentation entry found for '{}'", example_path));
+                GUI::MessageBox::show_error(this, MUST(String::formatted("No documentation entry found for '{}'", example_path)));
                 return;
             }
             auto& doc = doc_option.value();
@@ -98,13 +98,13 @@ HelpWindow::HelpWindow(GUI::Window* parent)
 
             auto maybe_example_data = doc.get_object("example_data"sv);
             if (!maybe_example_data.has_value()) {
-                GUI::MessageBox::show_error(this, DeprecatedString::formatted("No example data found for '{}'", example_path));
+                GUI::MessageBox::show_error(this, MUST(String::formatted("No example data found for '{}'", example_path)));
                 return;
             }
             auto& example_data = maybe_example_data.value();
 
             if (!example_data.has_object(name)) {
-                GUI::MessageBox::show_error(this, DeprecatedString::formatted("Example '{}' not found for '{}'", name, example_path));
+                GUI::MessageBox::show_error(this, MUST(String::formatted("Example '{}' not found for '{}'", name, example_path)));
                 return;
             }
             auto& value = example_data.get_object(name).value();
@@ -112,13 +112,13 @@ HelpWindow::HelpWindow(GUI::Window* parent)
             auto window = GUI::Window::construct(this);
             window->resize(size());
             window->set_icon(icon());
-            window->set_title(DeprecatedString::formatted("Spreadsheet Help - Example {} for {}", name, entry));
+            window->set_title(MUST(String::formatted("Spreadsheet Help - Example {} for {}", name, entry)).to_deprecated_string());
             window->on_close = [window = window.ptr()] { window->remove_from_parent(); };
 
             auto widget = window->set_main_widget<SpreadsheetWidget>(window, Vector<NonnullRefPtr<Sheet>> {}, false);
             auto sheet = Sheet::from_json(value, widget->workbook());
             if (!sheet) {
-                GUI::MessageBox::show_error(this, DeprecatedString::formatted("Corrupted example '{}' in '{}'", name, example_path));
+                GUI::MessageBox::show_error(this, MUST(String::formatted("Corrupted example '{}' in '{}'", name, example_path)));
                 return;
             }
 
@@ -141,7 +141,7 @@ HelpWindow::HelpWindow(GUI::Window* parent)
     };
 }
 
-DeprecatedString HelpWindow::render(StringView key)
+String HelpWindow::render(StringView key)
 {
     VERIFY(m_docs.has_object(key));
     auto& doc = m_docs.get_object(key).value();
@@ -194,7 +194,7 @@ DeprecatedString HelpWindow::render(StringView key)
     }
 
     auto document = Markdown::Document::parse(markdown_builder.string_view());
-    return document->render_to_html();
+    return MUST(String::from_deprecated_string(document->render_to_html()));
 }
 
 void HelpWindow::set_docs(JsonObject&& docs)

--- a/Userland/Applications/Spreadsheet/HelpWindow.h
+++ b/Userland/Applications/Spreadsheet/HelpWindow.h
@@ -32,7 +32,7 @@ public:
 
 private:
     static RefPtr<HelpWindow> s_the;
-    DeprecatedString render(StringView key);
+    String render(StringView key);
     HelpWindow(GUI::Window* parent = nullptr);
 
     JsonObject m_docs;

--- a/Userland/Applications/Spreadsheet/ImportDialog.cpp
+++ b/Userland/Applications/Spreadsheet/ImportDialog.cpp
@@ -53,7 +53,7 @@ CSVImportDialogPage::CSVImportDialogPage(StringView csv)
     m_data_preview_error_label = m_page->body_widget().find_descendant_of_type_named<GUI::Label>("data_preview_error_label");
     m_data_preview_widget = m_page->body_widget().find_descendant_of_type_named<GUI::StackWidget>("data_preview_widget");
 
-    m_quote_escape_combo_box->set_model(GUI::ItemListModel<DeprecatedString>::create(m_quote_escape_items));
+    m_quote_escape_combo_box->set_model(GUI::ItemListModel<String>::create(m_quote_escape_items));
 
     // By default, use commas, double quotes with repeat, and disable headers.
     m_delimiter_comma_radio->set_checked(true);
@@ -86,31 +86,31 @@ CSVImportDialogPage::CSVImportDialogPage(StringView csv)
 
 auto CSVImportDialogPage::make_reader() -> Optional<Reader::XSV>
 {
-    DeprecatedString delimiter;
-    DeprecatedString quote;
+    String delimiter;
+    String quote;
     Reader::ParserTraits::QuoteEscape quote_escape;
 
     // Delimiter
     if (m_delimiter_other_radio->is_checked())
-        delimiter = m_delimiter_other_text_box->text();
+        delimiter = MUST(String::from_deprecated_string(m_delimiter_other_text_box->text()));
     else if (m_delimiter_comma_radio->is_checked())
-        delimiter = ",";
+        delimiter = ","_string;
     else if (m_delimiter_semicolon_radio->is_checked())
-        delimiter = ";";
+        delimiter = ";"_string;
     else if (m_delimiter_tab_radio->is_checked())
-        delimiter = "\t";
+        delimiter = "\t"_string;
     else if (m_delimiter_space_radio->is_checked())
-        delimiter = " ";
+        delimiter = " "_string;
     else
         return {};
 
     // Quote separator
     if (m_quote_other_radio->is_checked())
-        quote = m_quote_other_text_box->text();
+        quote = MUST(String::from_deprecated_string(m_quote_other_text_box->text()));
     else if (m_quote_single_radio->is_checked())
-        quote = "'";
+        quote = "'"_string;
     else if (m_quote_double_radio->is_checked())
-        quote = "\"";
+        quote = "\""_string;
     else
         return {};
 
@@ -169,7 +169,7 @@ void CSVImportDialogPage::update_preview()
 
     Vector<String> headers;
     for (auto const& header : reader.headers())
-        headers.append(String::from_deprecated_string(header).release_value_but_fixme_should_propagate_errors());
+        headers.append(header);
 
     m_data_preview_table_view->set_model(
         GUI::ItemListModel<Reader::XSV::Row, Reader::XSV, Vector<String>>::create(reader, headers, min(8ul, reader.size())));
@@ -177,16 +177,16 @@ void CSVImportDialogPage::update_preview()
     m_data_preview_table_view->update();
 }
 
-ErrorOr<Vector<NonnullRefPtr<Sheet>>, DeprecatedString> ImportDialog::make_and_run_for(GUI::Window& parent, StringView mime, String const& filename, Core::File& file, Workbook& workbook)
+ErrorOr<Vector<NonnullRefPtr<Sheet>>, String> ImportDialog::make_and_run_for(GUI::Window& parent, StringView mime, String const& filename, Core::File& file, Workbook& workbook)
 {
     auto wizard = GUI::WizardDialog::create(&parent).release_value_but_fixme_should_propagate_errors();
     wizard->set_title("File Import Wizard");
     wizard->set_icon(GUI::Icon::default_icon("app-spreadsheet"sv).bitmap_for_size(16));
 
-    auto import_xsv = [&]() -> ErrorOr<Vector<NonnullRefPtr<Sheet>>, DeprecatedString> {
+    auto import_xsv = [&]() -> ErrorOr<Vector<NonnullRefPtr<Sheet>>, String> {
         auto contents_or_error = file.read_until_eof();
         if (contents_or_error.is_error())
-            return DeprecatedString::formatted("{}", contents_or_error.release_error());
+            return MUST(String::formatted("{}", contents_or_error.release_error()));
         CSVImportDialogPage page { contents_or_error.value() };
         wizard->replace_page(page.page());
         auto result = wizard->exec();
@@ -199,7 +199,7 @@ ErrorOr<Vector<NonnullRefPtr<Sheet>>, DeprecatedString> ImportDialog::make_and_r
             if (reader.has_value()) {
                 reader->parse();
                 if (reader.value().has_error())
-                    return DeprecatedString::formatted("CSV Import failed: {}", reader.value().error_string());
+                    return MUST(String::formatted("CSV Import failed: {}", reader.value().error_string()));
 
                 auto sheet = Sheet::from_xsv(reader.value(), workbook);
                 if (sheet)
@@ -209,20 +209,20 @@ ErrorOr<Vector<NonnullRefPtr<Sheet>>, DeprecatedString> ImportDialog::make_and_r
             return sheets;
         }
 
-        return DeprecatedString { "CSV Import was cancelled" };
+        return "CSV Import was cancelled"_string;
     };
 
-    auto import_worksheet = [&]() -> ErrorOr<Vector<NonnullRefPtr<Sheet>>, DeprecatedString> {
+    auto import_worksheet = [&]() -> ErrorOr<Vector<NonnullRefPtr<Sheet>>, String> {
         auto contents_or_error = file.read_until_eof();
         if (contents_or_error.is_error())
-            return DeprecatedString::formatted("{}", contents_or_error.release_error());
+            return MUST(String::formatted("{}", contents_or_error.release_error()));
         auto json_value_option = JsonParser(contents_or_error.release_value()).parse();
         if (json_value_option.is_error())
-            return DeprecatedString::formatted("Failed to parse {}", filename);
+            return MUST(String::formatted("Failed to parse {}", filename));
 
         auto& json_value = json_value_option.value();
         if (!json_value.is_array())
-            return DeprecatedString::formatted("Did not find a spreadsheet in {}", filename);
+            return MUST(String::formatted("Did not find a spreadsheet in {}", filename));
 
         Vector<NonnullRefPtr<Sheet>> sheets;
 
@@ -247,7 +247,7 @@ ErrorOr<Vector<NonnullRefPtr<Sheet>>, DeprecatedString> ImportDialog::make_and_r
     } else {
         auto page = GUI::WizardPage::create(
             "Import File Format"sv,
-            DeprecatedString::formatted("Select the format you wish to import '{}' as", LexicalPath::basename(filename.to_deprecated_string())))
+            MUST(String::formatted("Select the format you wish to import '{}' as", LexicalPath::basename(filename.to_deprecated_string()))))
                         .release_value_but_fixme_should_propagate_errors();
 
         page->on_next_page = [] { return nullptr; };
@@ -255,16 +255,16 @@ ErrorOr<Vector<NonnullRefPtr<Sheet>>, DeprecatedString> ImportDialog::make_and_r
         page->body_widget().load_from_gml(select_format_page_gml).release_value_but_fixme_should_propagate_errors();
         auto format_combo_box = page->body_widget().find_descendant_of_type_named<GUI::ComboBox>("select_format_page_format_combo_box");
 
-        Vector<DeprecatedString> supported_formats {
-            "CSV (text/csv)",
-            "Spreadsheet Worksheet",
+        Vector<String> supported_formats {
+            "CSV (text/csv)"_string,
+            "Spreadsheet Worksheet"_string,
         };
-        format_combo_box->set_model(GUI::ItemListModel<DeprecatedString>::create(supported_formats));
+        format_combo_box->set_model(GUI::ItemListModel<String>::create(supported_formats));
 
         wizard->push_page(page);
 
         if (wizard->exec() != GUI::Dialog::ExecResult::OK)
-            return DeprecatedString { "Import was cancelled" };
+            return "Import was cancelled"_string;
 
         if (format_combo_box->selected_index() == 0)
             return import_xsv();

--- a/Userland/Applications/Spreadsheet/ImportDialog.h
+++ b/Userland/Applications/Spreadsheet/ImportDialog.h
@@ -47,15 +47,15 @@ private:
     RefPtr<GUI::TableView> m_data_preview_table_view;
     RefPtr<GUI::Label> m_data_preview_error_label;
     RefPtr<GUI::StackWidget> m_data_preview_widget;
-    Vector<DeprecatedString> m_quote_escape_items {
+    Vector<String> m_quote_escape_items {
         // Note: Keep in sync with Reader::ParserTraits::QuoteEscape.
-        "Repeat",
-        "Backslash",
+        "Repeat"_string,
+        "Backslash"_string,
     };
 };
 
 struct ImportDialog {
-    static ErrorOr<Vector<NonnullRefPtr<Sheet>>, DeprecatedString> make_and_run_for(GUI::Window& parent, StringView mime, String const& filename, Core::File& file, Workbook&);
+    static ErrorOr<Vector<NonnullRefPtr<Sheet>>, String> make_and_run_for(GUI::Window& parent, StringView mime, String const& filename, Core::File& file, Workbook&);
 };
 
 }

--- a/Userland/Applications/Spreadsheet/JSIntegration.cpp
+++ b/Userland/Applications/Spreadsheet/JSIntegration.cpp
@@ -89,7 +89,7 @@ Optional<FunctionAndArgumentIndex> get_function_and_argument_index(StringView so
         token = lexer.next();
     }
     if (!names.is_empty() && !state.is_empty())
-        return FunctionAndArgumentIndex { names.last(), state.last() };
+        return FunctionAndArgumentIndex { MUST(String::from_utf8(names.last())), state.last() };
     return {};
 }
 
@@ -206,7 +206,7 @@ JS_DEFINE_NATIVE_FUNCTION(SheetGlobalObject::get_real_cell_contents)
         return JS::js_undefined();
 
     if (cell->kind() == Spreadsheet::Cell::Kind::Formula)
-        return JS::PrimitiveString::create(vm, DeprecatedString::formatted("={}", cell->data()));
+        return JS::PrimitiveString::create(vm, MUST(String::formatted("={}", cell->data())));
 
     return JS::PrimitiveString::create(vm, cell->data());
 }
@@ -226,7 +226,7 @@ JS_DEFINE_NATIVE_FUNCTION(SheetGlobalObject::set_real_cell_contents)
     auto name_value = vm.argument(0);
     if (!name_value.is_string())
         return vm.throw_completion<JS::TypeError>("Expected the first argument of set_real_cell_contents() to be a String"sv);
-    auto position = sheet_object.m_sheet.parse_cell_name(name_value.as_string().deprecated_string());
+    auto position = sheet_object.m_sheet.parse_cell_name(name_value.as_string().utf8_string().bytes_as_string_view());
     if (!position.has_value())
         return vm.throw_completion<JS::TypeError>("Invalid cell name"sv);
 
@@ -235,7 +235,7 @@ JS_DEFINE_NATIVE_FUNCTION(SheetGlobalObject::set_real_cell_contents)
         return vm.throw_completion<JS::TypeError>("Expected the second argument of set_real_cell_contents() to be a String"sv);
 
     auto& cell = sheet_object.m_sheet.ensure(position.value());
-    auto new_contents = new_contents_value.as_string().deprecated_string();
+    auto new_contents = new_contents_value.as_string().utf8_string();
     cell.set_data(new_contents);
     return JS::js_null();
 }
@@ -407,7 +407,7 @@ JS_DEFINE_NATIVE_FUNCTION(WorkbookObject::sheet)
     auto& workbook = workbook_object.m_workbook;
 
     if (name_value.is_string()) {
-        auto name = name_value.as_string().deprecated_string();
+        auto name = name_value.as_string().utf8_string();
         for (auto& sheet : workbook.sheets()) {
             if (sheet->name() == name)
                 return JS::Value(&sheet->global_object());

--- a/Userland/Applications/Spreadsheet/JSIntegration.h
+++ b/Userland/Applications/Spreadsheet/JSIntegration.h
@@ -14,7 +14,7 @@
 namespace Spreadsheet {
 
 struct FunctionAndArgumentIndex {
-    DeprecatedString function_name;
+    String function_name;
     size_t argument_index { 0 };
 };
 Optional<FunctionAndArgumentIndex> get_function_and_argument_index(StringView source);

--- a/Userland/Applications/Spreadsheet/Position.h
+++ b/Userland/Applications/Spreadsheet/Position.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <AK/DeprecatedString.h>
+#include <AK/String.h>
 #include <AK/Types.h>
 #include <AK/URL.h>
 
@@ -37,7 +37,7 @@ struct Position {
         return row == other.row && column == other.column;
     }
 
-    DeprecatedString to_cell_identifier(Sheet const& sheet) const;
+    String to_cell_identifier(Sheet const& sheet) const;
     URL to_url(Sheet const& sheet) const;
 
     size_t column { 0 };

--- a/Userland/Applications/Spreadsheet/Readers/CSV.h
+++ b/Userland/Applications/Spreadsheet/Readers/CSV.h
@@ -15,7 +15,7 @@ namespace Reader {
 class CSV : public XSV {
 public:
     CSV(StringView source, ParserBehavior behaviors = default_behaviors())
-        : XSV(source, { ",", "\"", ParserTraits::Repeat }, behaviors)
+        : XSV(source, { ","_string, "\""_string, ParserTraits::Repeat }, behaviors)
     {
     }
 };

--- a/Userland/Applications/Spreadsheet/Readers/XSV.cpp
+++ b/Userland/Applications/Spreadsheet/Readers/XSV.cpp
@@ -25,19 +25,19 @@ void XSV::set_error(ReadError error)
         m_error = error;
 }
 
-Vector<DeprecatedString> XSV::headers() const
+Vector<String> XSV::headers() const
 {
-    Vector<DeprecatedString> headers;
+    Vector<String> headers;
     if (has_explicit_headers()) {
         for (auto& field : m_names)
-            headers.append(field.is_string_view ? field.as_string_view : field.as_string.view());
+            headers.append(field.is_string_view ? MUST(String::from_utf8(field.as_string_view)) : field.as_string);
     } else {
         // No headers read, grab one of the rows and generate empty names
         if (m_rows.is_empty())
             return headers;
 
         for ([[maybe_unused]] auto& field : m_rows.first())
-            headers.append(DeprecatedString::empty());
+            headers.append({});
     }
 
     return headers;
@@ -89,7 +89,7 @@ Vector<XSV::Field> XSV::read_row(bool header_row)
 {
     Vector<Field> row;
     bool first = true;
-    while (!(m_lexer.is_eof() || m_lexer.next_is('\n') || m_lexer.next_is("\r\n")) && (first || m_lexer.consume_specific(m_traits.separator.view()))) {
+    while (!(m_lexer.is_eof() || m_lexer.next_is('\n') || m_lexer.next_is("\r\n")) && (first || m_lexer.consume_specific(m_traits.separator))) {
         first = false;
         row.append(read_one_field());
     }
@@ -137,7 +137,7 @@ XSV::Field XSV::read_one_field()
 
     bool is_quoted = false;
     Field field;
-    if (m_lexer.next_is(m_traits.quote.view())) {
+    if (m_lexer.next_is(m_traits.quote.bytes_as_string_view())) {
         is_quoted = true;
         field = read_one_quoted_field();
     } else {
@@ -167,7 +167,7 @@ XSV::Field XSV::read_one_field()
             if (field.is_string_view)
                 field.as_string_view = view;
             else
-                field.as_string = field.as_string.substring(0, view.length());
+                field.as_string = MUST(field.as_string.substring_from_byte_offset(0, view.length()));
         }
     }
 
@@ -176,7 +176,7 @@ XSV::Field XSV::read_one_field()
 
 XSV::Field XSV::read_one_quoted_field()
 {
-    if (!m_lexer.consume_specific(m_traits.quote.view()))
+    if (!m_lexer.consume_specific(m_traits.quote.bytes_as_string_view()))
         set_error(ReadError::InternalError);
 
     size_t start = m_lexer.tell(), end = start;
@@ -188,7 +188,7 @@ XSV::Field XSV::read_one_quoted_field()
         char ch;
         switch (m_traits.quote_escape) {
         case ParserTraits::Backslash:
-            if (m_lexer.consume_specific('\\') && m_lexer.consume_specific(m_traits.quote.view())) {
+            if (m_lexer.consume_specific('\\') && m_lexer.consume_specific(m_traits.quote.bytes_as_string_view())) {
                 // If there is an escaped quote, we have no choice but to make a copy.
                 if (!is_copy) {
                     is_copy = true;
@@ -200,8 +200,8 @@ XSV::Field XSV::read_one_quoted_field()
             }
             break;
         case ParserTraits::Repeat:
-            if (m_lexer.consume_specific(m_traits.quote.view())) {
-                if (m_lexer.consume_specific(m_traits.quote.view())) {
+            if (m_lexer.consume_specific(m_traits.quote.bytes_as_string_view())) {
+                if (m_lexer.consume_specific(m_traits.quote.bytes_as_string_view())) {
                     // If there is an escaped quote, we have no choice but to make a copy.
                     if (!is_copy) {
                         is_copy = true;
@@ -211,14 +211,14 @@ XSV::Field XSV::read_one_quoted_field()
                     end = m_lexer.tell();
                     continue;
                 }
-                for (size_t i = 0; i < m_traits.quote.length(); ++i)
+                for (size_t i = 0; i < m_traits.quote.bytes().size(); ++i)
                     m_lexer.retreat();
                 goto end;
             }
             break;
         }
 
-        if (m_lexer.next_is(m_traits.quote.view()))
+        if (m_lexer.next_is(m_traits.quote.bytes_as_string_view()))
             goto end;
 
         if (!allow_newlines) {
@@ -236,11 +236,11 @@ XSV::Field XSV::read_one_quoted_field()
         break;
     }
 
-    if (!m_lexer.consume_specific(m_traits.quote.view()))
+    if (!m_lexer.consume_specific(m_traits.quote))
         set_error(ReadError::QuoteFailure);
 
     if (is_copy)
-        return { {}, builder.to_deprecated_string(), false };
+        return { {}, MUST(builder.to_string()), false };
 
     return { m_source.substring_view(start, end - start), {}, true };
 }
@@ -251,13 +251,13 @@ XSV::Field XSV::read_one_unquoted_field()
     bool allow_quote_in_field = (m_behaviors & ParserBehavior::QuoteOnlyInFieldStart) != ParserBehavior::None;
 
     for (; !m_lexer.is_eof();) {
-        if (m_lexer.next_is(m_traits.separator.view()))
+        if (m_lexer.next_is(m_traits.separator.bytes_as_string_view()))
             break;
 
         if (m_lexer.next_is("\r\n") || m_lexer.next_is("\n"))
             break;
 
-        if (m_lexer.consume_specific(m_traits.quote.view())) {
+        if (m_lexer.consume_specific(m_traits.quote)) {
             if (!allow_quote_in_field)
                 set_error(ReadError::QuoteFailure);
             end = m_lexer.tell();

--- a/Userland/Applications/Spreadsheet/Readers/XSV.h
+++ b/Userland/Applications/Spreadsheet/Readers/XSV.h
@@ -6,8 +6,8 @@
 
 #pragma once
 
-#include <AK/DeprecatedString.h>
 #include <AK/GenericLexer.h>
+#include <AK/String.h>
 #include <AK/StringView.h>
 #include <AK/Types.h>
 #include <AK/Vector.h>
@@ -31,20 +31,20 @@ ParserBehavior operator&(ParserBehavior left, ParserBehavior right);
 ParserBehavior operator|(ParserBehavior left, ParserBehavior right);
 
 struct ParserTraits {
-    DeprecatedString separator;
-    DeprecatedString quote { "\"" };
+    String separator;
+    String quote { "\""_string };
     enum QuoteEscape {
         Repeat,
         Backslash,
     } quote_escape { Repeat };
 };
 
-#define ENUMERATE_READ_ERRORS()                                                   \
-    E(None, "No errors")                                                          \
-    E(NonConformingColumnCount, "Header count does not match given column count") \
-    E(QuoteFailure, "Quoting failure")                                            \
-    E(InternalError, "Internal error")                                            \
-    E(DataPastLogicalEnd, "Extra data past the logical end of the rows")
+#define ENUMERATE_READ_ERRORS()                                                          \
+    E(None, "No errors"_string)                                                          \
+    E(NonConformingColumnCount, "Header count does not match given column count"_string) \
+    E(QuoteFailure, "Quoting failure"_string)                                            \
+    E(InternalError, "Internal error"_string)                                            \
+    E(DataPastLogicalEnd, "Extra data past the logical end of the rows"_string)
 
 enum class ReadError {
 #define E(name, _) name,
@@ -73,7 +73,7 @@ public:
     void parse();
     bool has_error() const { return m_error != ReadError::None; }
     ReadError error() const { return m_error; }
-    DeprecatedString error_string() const
+    String error_string() const
     {
         switch (m_error) {
 #define E(x, y)        \
@@ -87,7 +87,7 @@ public:
     }
 
     size_t size() const { return m_rows.size(); }
-    Vector<DeprecatedString> headers() const;
+    Vector<String> headers() const;
     [[nodiscard]] bool has_explicit_headers() const { return (static_cast<u32>(m_behaviors) & static_cast<u32>(ParserBehavior::ReadHeaders)) != 0; }
 
     class Row {
@@ -185,7 +185,7 @@ public:
 private:
     struct Field {
         StringView as_string_view;
-        DeprecatedString as_string; // This member only used if the parser couldn't use the original source verbatim.
+        String as_string; // This member only used if the parser couldn't use the original source verbatim.
         bool is_string_view { true };
 
         bool operator==(StringView other) const

--- a/Userland/Applications/Spreadsheet/Spreadsheet.cpp
+++ b/Userland/Applications/Spreadsheet/Spreadsheet.cpp
@@ -14,6 +14,7 @@
 #include <AK/JsonObject.h>
 #include <AK/JsonParser.h>
 #include <AK/ScopeGuard.h>
+#include <AK/String.h>
 #include <AK/TemporaryChange.h>
 #include <AK/URL.h>
 #include <LibCore/File.h>
@@ -30,7 +31,7 @@ namespace Spreadsheet {
 Sheet::Sheet(StringView name, Workbook& workbook)
     : Sheet(workbook)
 {
-    m_name = name;
+    m_name = MUST(String::from_utf8(name));
 
     for (size_t i = 0; i < default_row_count; ++i)
         add_row();
@@ -113,9 +114,9 @@ static Optional<size_t> convert_from_string(StringView str, unsigned base = 26, 
     return value - 1;
 }
 
-DeprecatedString Sheet::add_column()
+String Sheet::add_column()
 {
-    auto next_column = DeprecatedString::bijective_base_from(m_columns.size());
+    auto next_column = MUST(String::from_deprecated_string(DeprecatedString::bijective_base_from(m_columns.size())));
     m_columns.append(next_column);
     return next_column;
 }
@@ -204,7 +205,7 @@ Optional<Position> Sheet::parse_cell_name(StringView name) const
     if (!lexer.is_eof() || row.is_empty() || col.is_empty())
         return {};
 
-    auto it = m_columns.find(col);
+    auto it = m_columns.find(MUST(String::from_utf8(col)));
     if (it == m_columns.end())
         return {};
 
@@ -219,7 +220,7 @@ Optional<size_t> Sheet::column_index(StringView column_name) const
 
     auto index = maybe_index.value();
     if (m_columns.size() <= index || m_columns[index] != column_name) {
-        auto it = m_columns.find(column_name);
+        auto it = m_columns.find(MUST(String::from_utf8(column_name)));
         if (it == m_columns.end())
             return {};
         index = it.index();
@@ -228,7 +229,7 @@ Optional<size_t> Sheet::column_index(StringView column_name) const
     return index;
 }
 
-Optional<DeprecatedString> Sheet::column_arithmetic(StringView column_name, int offset)
+Optional<String> Sheet::column_arithmetic(StringView column_name, int offset)
 {
     auto maybe_index = column_index(column_name);
     if (!maybe_index.has_value())
@@ -269,7 +270,7 @@ Optional<Position> Sheet::position_from_url(const URL& url) const
     }
 
     // FIXME: Figure out a way to do this cross-process.
-    VERIFY(url.serialize_path() == DeprecatedString::formatted("/{}", getpid()));
+    VERIFY(url.serialize_path() == MUST(String::formatted("/{}", getpid())));
 
     return parse_cell_name(url.fragment().value_or(String {}));
 }
@@ -314,7 +315,7 @@ Vector<CellChange> Sheet::copy_cells(Vector<Position> from, Vector<Position> to,
         auto previous_data = target_cell.data();
 
         if (!source_cell) {
-            target_cell.set_data("");
+            target_cell.set_data(""_string);
             cell_changes.append(CellChange(target_cell, previous_data));
             return;
         }
@@ -323,7 +324,7 @@ Vector<CellChange> Sheet::copy_cells(Vector<Position> from, Vector<Position> to,
         cell_changes.append(CellChange(target_cell, previous_data));
         if (copy_operation == CopyOperation::Cut && !target_cells.contains_slow(source_position)) {
             cell_changes.append(CellChange(*source_cell, source_cell->data()));
-            source_cell->set_data("");
+            source_cell->set_data(""_string);
         }
     };
 
@@ -380,7 +381,7 @@ RefPtr<Sheet> Sheet::from_json(JsonObject const& object, Workbook& workbook)
     if (object.has("cells"sv) && !object.has_object("cells"sv))
         return {};
 
-    sheet->set_name(name);
+    sheet->set_name(MUST(String::from_deprecated_string(name)));
 
     for (size_t i = 0; i < max(rows, (unsigned)Sheet::default_row_count); ++i)
         sheet->add_row();
@@ -388,7 +389,7 @@ RefPtr<Sheet> Sheet::from_json(JsonObject const& object, Workbook& workbook)
     // FIXME: Better error checking.
     if (columns.has_value()) {
         columns->for_each([&](auto& value) {
-            sheet->m_columns.append(value.as_string());
+            sheet->m_columns.append(MUST(String::from_deprecated_string(value.as_string())));
             return IterationDecision::Continue;
         });
     }
@@ -421,7 +422,7 @@ RefPtr<Sheet> Sheet::from_json(JsonObject const& object, Workbook& workbook)
             OwnPtr<Cell> cell;
             switch (kind) {
             case Cell::LiteralString:
-                cell = make<Cell>(obj.get_deprecated_string("value"sv).value_or({}), position, *sheet);
+                cell = make<Cell>(MUST(String::from_deprecated_string(obj.get_deprecated_string("value"sv).value_or({}))), position, *sheet);
                 break;
             case Cell::Formula: {
                 auto& vm = sheet->vm();
@@ -430,7 +431,7 @@ RefPtr<Sheet> Sheet::from_json(JsonObject const& object, Workbook& workbook)
                     warnln("Failed to load previous value for cell {}, leaving as undefined", position.to_cell_identifier(sheet));
                     value_or_error = JS::js_undefined();
                 }
-                cell = make<Cell>(obj.get_deprecated_string("source"sv).value_or({}), value_or_error.release_value(), position, *sheet);
+                cell = make<Cell>(MUST(String::from_deprecated_string(obj.get_deprecated_string("source"sv).value_or({}))), value_or_error.release_value(), position, *sheet);
                 break;
             }
             }
@@ -445,7 +446,7 @@ RefPtr<Sheet> Sheet::from_json(JsonObject const& object, Workbook& workbook)
                 if (auto value = meta_obj.get_i32("length"sv); value.has_value())
                     meta.length = value.value();
                 if (auto value = meta_obj.get_deprecated_string("format"sv); value.has_value())
-                    meta.format = value.value();
+                    meta.format = MUST(String::from_deprecated_string(value.value()));
                 if (auto value = meta_obj.get_deprecated_string("alignment"sv); value.has_value()) {
                     auto alignment = Gfx::text_alignment_from_string(*value);
                     if (alignment.has_value())
@@ -464,7 +465,7 @@ RefPtr<Sheet> Sheet::from_json(JsonObject const& object, Workbook& workbook)
                         return IterationDecision::Continue;
 
                     auto& fmt_obj = fmt_val.as_object();
-                    auto fmt_cond = fmt_obj.get_deprecated_string("condition"sv).value_or({});
+                    auto fmt_cond = MUST(String::from_deprecated_string(fmt_obj.get_deprecated_string("condition"sv).value_or({})));
                     if (fmt_cond.is_empty())
                         return IterationDecision::Continue;
 
@@ -517,7 +518,7 @@ Position Sheet::written_data_bounds(Optional<size_t> column_index) const
 bool Sheet::columns_are_standard() const
 {
     for (size_t i = 0; i < m_columns.size(); ++i) {
-        if (m_columns[i] != DeprecatedString::bijective_base_from(i))
+        if (m_columns[i] != MUST(String::from_deprecated_string(DeprecatedString::bijective_base_from(i))))
             return false;
     }
 
@@ -527,7 +528,7 @@ bool Sheet::columns_are_standard() const
 JsonObject Sheet::to_json() const
 {
     JsonObject object;
-    object.set("name", m_name);
+    object.set("name", m_name.to_deprecated_string());
 
     auto save_format = [](auto const& format, auto& obj) {
         if (format.foreground_color.has_value())
@@ -541,7 +542,7 @@ JsonObject Sheet::to_json() const
     if (!columns_are_standard()) {
         auto columns = JsonArray();
         for (auto& column : m_columns)
-            columns.must_append(column);
+            columns.must_append(column.to_deprecated_string());
         object.set("columns", move(columns));
     }
     object.set("rows", bottom_right.row + 1);
@@ -556,23 +557,23 @@ JsonObject Sheet::to_json() const
         JsonObject data;
         data.set("kind", it.value->kind() == Cell::Kind::Formula ? "Formula" : "LiteralString");
         if (it.value->kind() == Cell::Formula) {
-            data.set("source", it.value->data());
+            data.set("source", it.value->data().to_deprecated_string());
             auto json = realm().global_object().get_without_side_effects("JSON");
             auto stringified_or_error = JS::call(vm(), json.as_object().get_without_side_effects("stringify").as_function(), json, it.value->evaluated_data());
             VERIFY(!stringified_or_error.is_error());
             data.set("value", stringified_or_error.release_value().to_string_without_side_effects().to_deprecated_string());
         } else {
-            data.set("value", it.value->data());
+            data.set("value", it.value->data().to_deprecated_string());
         }
 
         // Set type & meta
         auto& type = it.value->type();
         auto& meta = it.value->type_metadata();
-        data.set("type", type.name());
+        data.set("type", type.name().to_deprecated_string());
 
         JsonObject metadata_object;
         metadata_object.set("length", meta.length);
-        metadata_object.set("format", meta.format);
+        metadata_object.set("format", meta.format.to_deprecated_string());
         metadata_object.set("alignment", Gfx::to_string(meta.alignment));
         save_format(meta.static_format, metadata_object);
 
@@ -582,7 +583,7 @@ JsonObject Sheet::to_json() const
         JsonArray conditional_formats;
         for (auto& fmt : it.value->conditional_formats()) {
             JsonObject fmt_object;
-            fmt_object.set("condition", fmt.condition);
+            fmt_object.set("condition", fmt.condition.to_deprecated_string());
             save_format(fmt, fmt_object);
 
             conditional_formats.must_append(move(fmt_object));
@@ -603,9 +604,9 @@ JsonObject Sheet::to_json() const
     return object;
 }
 
-Vector<Vector<DeprecatedString>> Sheet::to_xsv() const
+Vector<Vector<String>> Sheet::to_xsv() const
 {
-    Vector<Vector<DeprecatedString>> data;
+    Vector<Vector<String>> data;
 
     auto bottom_right = written_data_bounds();
 
@@ -613,7 +614,7 @@ Vector<Vector<DeprecatedString>> Sheet::to_xsv() const
     size_t column_count = m_columns.size();
     if (columns_are_standard()) {
         column_count = bottom_right.column + 1;
-        Vector<DeprecatedString> cols;
+        Vector<String> cols;
         for (size_t i = 0; i < column_count; ++i)
             cols.append(m_columns[i]);
         data.append(move(cols));
@@ -622,7 +623,7 @@ Vector<Vector<DeprecatedString>> Sheet::to_xsv() const
     }
 
     for (size_t i = 0; i <= bottom_right.row; ++i) {
-        Vector<DeprecatedString> row;
+        Vector<String> row;
         row.resize(column_count);
         for (size_t j = 0; j < column_count; ++j) {
             auto cell = at({ j, i });
@@ -650,7 +651,7 @@ RefPtr<Sheet> Sheet::from_xsv(Reader::XSV const& xsv, Workbook& workbook)
     } else {
         sheet->m_columns.ensure_capacity(cols.size());
         for (size_t i = 0; i < cols.size(); ++i)
-            sheet->m_columns.append(DeprecatedString::bijective_base_from(i));
+            sheet->m_columns.append(MUST(String::from_deprecated_string(DeprecatedString::bijective_base_from(i))));
     }
     for (size_t i = 0; i < max(rows, Sheet::default_row_count); ++i)
         sheet->add_row();
@@ -665,7 +666,7 @@ RefPtr<Sheet> Sheet::from_xsv(Reader::XSV const& xsv, Workbook& workbook)
             if (str.is_empty())
                 continue;
             Position position { i, row.index() };
-            auto cell = make<Cell>(str, position, *sheet);
+            auto cell = make<Cell>(MUST(String::from_utf8(str)), position, *sheet);
             sheet->m_cells.set(position, move(cell));
         }
     }
@@ -710,7 +711,7 @@ JsonObject Sheet::gather_documentation() const
     return m_cached_documentation.value();
 }
 
-DeprecatedString Sheet::generate_inline_documentation_for(StringView function, size_t argument_index)
+String Sheet::generate_inline_documentation_for(StringView function, size_t argument_index)
 {
     if (!m_cached_documentation.has_value())
         gather_documentation();
@@ -718,13 +719,13 @@ DeprecatedString Sheet::generate_inline_documentation_for(StringView function, s
     auto& docs = m_cached_documentation.value();
     auto entry = docs.get_object(function);
     if (!entry.has_value())
-        return DeprecatedString::formatted("{}(...???{})", function, argument_index);
+        return MUST(String::formatted("{}(...???{})", function, argument_index));
 
     auto& entry_object = entry.value();
     size_t argc = entry_object.get_integer<int>("argc"sv).value_or(0);
     auto argnames_value = entry_object.get_array("argnames"sv);
     if (!argnames_value.has_value())
-        return DeprecatedString::formatted("{}(...{}???{})", function, argc, argument_index);
+        return MUST(String::formatted("{}(...{}???{})", function, argc, argument_index));
     auto& argnames = argnames_value.value();
     StringBuilder builder;
     builder.appendff("{}(", function);
@@ -743,12 +744,12 @@ DeprecatedString Sheet::generate_inline_documentation_for(StringView function, s
     }
 
     builder.append(')');
-    return builder.to_deprecated_string();
+    return MUST(builder.to_string());
 }
 
-DeprecatedString Position::to_cell_identifier(Sheet const& sheet) const
+String Position::to_cell_identifier(Sheet const& sheet) const
 {
-    return DeprecatedString::formatted("{}{}", sheet.column(column), row);
+    return MUST(String::formatted("{}{}", sheet.column(column), row));
 }
 
 URL Position::to_url(Sheet const& sheet) const
@@ -757,11 +758,11 @@ URL Position::to_url(Sheet const& sheet) const
     url.set_scheme("spreadsheet"_string);
     url.set_host("cell"_string);
     url.set_paths({ DeprecatedString::number(getpid()) });
-    url.set_fragment(String::from_deprecated_string(to_cell_identifier(sheet)).release_value());
+    url.set_fragment(to_cell_identifier(sheet));
     return url;
 }
 
-CellChange::CellChange(Cell& cell, DeprecatedString const& previous_data)
+CellChange::CellChange(Cell& cell, String const& previous_data)
     : m_cell(cell)
     , m_previous_data(previous_data)
 {

--- a/Userland/Applications/Spreadsheet/Spreadsheet.h
+++ b/Userland/Applications/Spreadsheet/Spreadsheet.h
@@ -9,9 +9,9 @@
 #include "Cell.h"
 #include "Forward.h"
 #include "Readers/XSV.h"
-#include <AK/DeprecatedString.h>
 #include <AK/HashMap.h>
 #include <AK/HashTable.h>
+#include <AK/String.h>
 #include <AK/StringBuilder.h>
 #include <AK/Traits.h>
 #include <AK/Types.h>
@@ -23,7 +23,7 @@ namespace Spreadsheet {
 
 class CellChange {
 public:
-    CellChange(Cell&, DeprecatedString const&);
+    CellChange(Cell&, String const&);
     CellChange(Cell&, CellTypeMetadata const&);
 
     auto& cell() { return m_cell; }
@@ -34,8 +34,8 @@ public:
 
 private:
     Cell& m_cell;
-    DeprecatedString m_previous_data;
-    DeprecatedString m_new_data;
+    String m_previous_data;
+    String m_new_data;
     CellTypeMetadata m_previous_type_metadata;
     CellTypeMetadata m_new_type_metadata;
 };
@@ -51,7 +51,7 @@ public:
 
     Optional<Position> parse_cell_name(StringView) const;
     Optional<size_t> column_index(StringView column_name) const;
-    Optional<DeprecatedString> column_arithmetic(StringView column_name, int offset);
+    Optional<String> column_arithmetic(StringView column_name, int offset);
 
     Cell* from_url(const URL&);
     Cell const* from_url(const URL& url) const { return const_cast<Sheet*>(this)->from_url(url); }
@@ -64,11 +64,11 @@ public:
     JsonObject to_json() const;
     static RefPtr<Sheet> from_json(JsonObject const&, Workbook&);
 
-    Vector<Vector<DeprecatedString>> to_xsv() const;
+    Vector<Vector<String>> to_xsv() const;
     static RefPtr<Sheet> from_xsv(Reader::XSV const&, Workbook&);
 
-    DeprecatedString const& name() const { return m_name; }
-    void set_name(StringView name) { m_name = name; }
+    String const& name() const { return m_name; }
+    void set_name(String name) { m_name = move(name); }
 
     JsonObject gather_documentation() const;
 
@@ -89,17 +89,17 @@ public:
         if (auto cell = at(position))
             return *cell;
 
-        m_cells.set(position, make<Cell>(DeprecatedString::empty(), position, *this));
+        m_cells.set(position, make<Cell>(String {}, position, *this));
         return *at(position);
     }
 
     size_t add_row();
-    DeprecatedString add_column();
+    String add_column();
 
     size_t row_count() const { return m_rows; }
     size_t column_count() const { return m_columns.size(); }
-    Vector<DeprecatedString> const& columns() const { return m_columns; }
-    DeprecatedString const& column(size_t index)
+    Vector<String> const& columns() const { return m_columns; }
+    String const& column(size_t index)
     {
         for (size_t i = column_count(); i < index; ++i)
             add_column();
@@ -107,7 +107,7 @@ public:
         VERIFY(column_count() > index);
         return m_columns[index];
     }
-    DeprecatedString const& column(size_t index) const
+    String const& column(size_t index) const
     {
         VERIFY(column_count() > index);
         return m_columns[index];
@@ -145,7 +145,7 @@ public:
 
     bool columns_are_standard() const;
 
-    DeprecatedString generate_inline_documentation_for(StringView function, size_t argument_index);
+    String generate_inline_documentation_for(StringView function, size_t argument_index);
 
     JS::Realm& realm() const { return *m_root_execution_context->realm; }
     JS::VM& vm() const { return realm().vm(); }
@@ -154,8 +154,8 @@ private:
     explicit Sheet(Workbook&);
     explicit Sheet(StringView name, Workbook&);
 
-    DeprecatedString m_name;
-    Vector<DeprecatedString> m_columns;
+    String m_name;
+    Vector<String> m_columns;
     size_t m_rows { 0 };
     HashMap<Position, NonnullOwnPtr<Cell>> m_cells;
     HashTable<Position> m_selected_cells;

--- a/Userland/Applications/Spreadsheet/SpreadsheetModel.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetModel.cpp
@@ -21,9 +21,9 @@ GUI::Variant SheetModel::data(const GUI::ModelIndex& index, GUI::ModelRole role)
     if (role == GUI::ModelRole::Display) {
         auto const* cell = m_sheet->at({ (size_t)index.column(), (size_t)index.row() });
         if (!cell)
-            return DeprecatedString::empty();
+            return String {};
 
-        Function<DeprecatedString(JS::Value)> to_deprecated_string_as_exception = [&](JS::Value value) {
+        Function<String(JS::Value)> to_string_as_exception = [&](JS::Value value) {
             auto& vm = cell->sheet().global_object().vm();
             StringBuilder builder;
             builder.append("Error: "sv);
@@ -31,31 +31,31 @@ GUI::Variant SheetModel::data(const GUI::ModelIndex& index, GUI::ModelRole role)
                 auto& object = value.as_object();
                 if (is<JS::Error>(object)) {
                     auto message = object.get_without_side_effects("message");
-                    auto error = message.to_deprecated_string(vm);
+                    auto error = message.to_string(vm);
                     if (error.is_throw_completion())
                         builder.append(message.to_string_without_side_effects());
                     else
                         builder.append(error.release_value());
-                    return builder.to_deprecated_string();
+                    return MUST(builder.to_string());
                 }
             }
-            auto error_message = value.to_deprecated_string(vm);
+            auto error_message = value.to_string(vm);
 
             if (error_message.is_throw_completion())
-                return to_deprecated_string_as_exception(*error_message.release_error().value());
+                return to_string_as_exception(*error_message.release_error().value());
 
             builder.append(error_message.release_value());
-            return builder.to_deprecated_string();
+            return MUST(builder.to_string());
         };
 
         if (cell->kind() == Spreadsheet::Cell::Formula) {
             if (auto opt_throw_value = cell->thrown_value(); opt_throw_value.has_value())
-                return to_deprecated_string_as_exception(*opt_throw_value);
+                return to_string_as_exception(*opt_throw_value);
         }
 
         auto display = cell->typed_display();
         if (display.is_error())
-            return to_deprecated_string_as_exception(*display.release_error().value());
+            return to_string_as_exception(*display.release_error().value());
 
         return display.release_value();
     }
@@ -154,10 +154,10 @@ RefPtr<Core::MimeData> SheetModel::mime_data(const GUI::ModelSelection& selectio
 
     Position cursor_position { (size_t)cursor->column(), (size_t)cursor->row() };
     auto mime_data_buffer = mime_data->data("text/x-spreadsheet-data"sv);
-    auto new_data = DeprecatedString::formatted("{}\n{}",
+    auto new_data = MUST(String::formatted("{}\n{}",
         cursor_position.to_url(m_sheet).to_deprecated_string(),
-        StringView(mime_data_buffer));
-    mime_data->set_data("text/x-spreadsheet-data"_string, new_data.to_byte_buffer());
+        StringView(mime_data_buffer)));
+    mime_data->set_data("text/x-spreadsheet-data"_string, MUST(ByteBuffer::copy(new_data.bytes())));
 
     return mime_data;
 }
@@ -167,7 +167,7 @@ ErrorOr<String> SheetModel::column_name(int index) const
     if (index < 0)
         return String {};
 
-    return TRY(String::from_deprecated_string(m_sheet->column(index)));
+    return m_sheet->column(index);
 }
 
 bool SheetModel::is_editable(const GUI::ModelIndex& index) const
@@ -185,7 +185,7 @@ void SheetModel::set_data(const GUI::ModelIndex& index, const GUI::Variant& valu
 
     auto& cell = m_sheet->ensure({ (size_t)index.column(), (size_t)index.row() });
     auto previous_data = cell.data();
-    cell.set_data(value.to_deprecated_string());
+    cell.set_data(MUST(String::from_deprecated_string(value.to_deprecated_string())));
     if (on_cell_data_change)
         on_cell_data_change(cell, previous_data);
     did_update(UpdateFlag::DontInvalidateIndices);
@@ -202,7 +202,7 @@ CellsUndoCommand::CellsUndoCommand(Vector<CellChange> cell_changes)
     m_cell_changes = cell_changes;
 }
 
-CellsUndoCommand::CellsUndoCommand(Cell& cell, DeprecatedString const& previous_data)
+CellsUndoCommand::CellsUndoCommand(Cell& cell, String const& previous_data)
 {
     m_cell_changes.append(CellChange(cell, previous_data));
 }

--- a/Userland/Applications/Spreadsheet/SpreadsheetModel.h
+++ b/Userland/Applications/Spreadsheet/SpreadsheetModel.h
@@ -34,7 +34,7 @@ public:
 
     void update();
 
-    Function<void(Cell&, DeprecatedString&)> on_cell_data_change;
+    Function<void(Cell&, String&)> on_cell_data_change;
     Function<void(Vector<CellChange>)> on_cells_data_change;
 
 private:
@@ -48,7 +48,7 @@ private:
 
 class CellsUndoCommand : public GUI::Command {
 public:
-    CellsUndoCommand(Cell&, DeprecatedString const&);
+    CellsUndoCommand(Cell&, String const&);
     CellsUndoCommand(Vector<CellChange>);
 
     virtual void undo() override;

--- a/Userland/Applications/Spreadsheet/SpreadsheetView.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetView.cpp
@@ -448,7 +448,7 @@ SpreadsheetView::SpreadsheetView(Sheet& sheet)
 
         if (event.mime_data().has_text()) {
             auto& target_cell = m_sheet->ensure({ (size_t)index.column(), (size_t)index.row() });
-            target_cell.set_data(event.text());
+            target_cell.set_data(MUST(String::from_deprecated_string(event.text())));
             return;
         }
     };

--- a/Userland/Applications/Spreadsheet/SpreadsheetWidget.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetWidget.cpp
@@ -23,7 +23,6 @@
 #include <LibGUI/Toolbar.h>
 #include <LibGUI/ToolbarContainer.h>
 #include <LibGfx/Font/FontDatabase.h>
-#include <string.h>
 
 namespace Spreadsheet {
 
@@ -99,7 +98,7 @@ SpreadsheetWidget::SpreadsheetWidget(GUI::Window& parent_window, Vector<NonnullR
         auto* sheet_ptr = m_tab_context_menu_sheet_view->sheet_if_available();
         VERIFY(sheet_ptr); // How did we get here without a sheet?
         auto& sheet = *sheet_ptr;
-        String new_name = String::from_deprecated_string(sheet.name()).release_value_but_fixme_should_propagate_errors();
+        String new_name = sheet.name();
         if (GUI::InputBox::show(window(), new_name, {}, "Rename Sheet"sv, GUI::InputType::NonemptyText, "Name"sv) == GUI::Dialog::ExecResult::OK) {
             sheet.set_name(new_name);
             sheet.update();
@@ -159,15 +158,15 @@ SpreadsheetWidget::SpreadsheetWidget(GUI::Window& parent_window, Vector<NonnullR
             return;
         }
 
-        auto response = FileSystemAccessClient::Client::the().request_file(window(), current_filename(), Core::File::OpenMode::Write);
+        auto response = FileSystemAccessClient::Client::the().request_file(window(), current_filename().to_deprecated_string(), Core::File::OpenMode::Write);
         if (response.is_error())
             return;
         save(response.value().filename(), response.value().stream());
     });
 
     m_save_as_action = GUI::CommonActions::make_save_as_action([&](auto&) {
-        DeprecatedString name = "workbook";
-        auto response = FileSystemAccessClient::Client::the().save_file(window(), name, "sheets");
+        String name = "workbook"_string;
+        auto response = FileSystemAccessClient::Client::the().save_file(window(), name.to_deprecated_string(), "sheets");
         if (response.is_error())
             return;
         save(response.value().filename(), response.value().stream());
@@ -216,8 +215,15 @@ SpreadsheetWidget::SpreadsheetWidget(GUI::Window& parent_window, Vector<NonnullR
             auto cell_changes = sheet.copy_cells(move(source_positions), move(target_positions), first_position, action == "cut" ? Spreadsheet::Sheet::CopyOperation::Cut : Spreadsheet::Sheet::CopyOperation::Copy);
             undo_stack().push(make<CellsUndoCommand>(cell_changes));
         } else {
+            auto maybe_string = String::from_utf8(data.data);
+            if (maybe_string.is_error()) {
+                dbgln("Invalid pasted string: {}", maybe_string.release_error());
+                return;
+            }
+            auto string = maybe_string.release_value();
+
             for (auto& cell : sheet.selected_cells())
-                sheet.ensure(cell).set_data(StringView { data.data.data(), data.data.size() });
+                sheet.ensure(cell).set_data(string);
             update();
         }
     },
@@ -228,7 +234,7 @@ SpreadsheetWidget::SpreadsheetWidget(GUI::Window& parent_window, Vector<NonnullR
         if (emoji_input_dialog->exec() != GUI::EmojiInputDialog::ExecResult::OK)
             return;
 
-        auto emoji_code_point = emoji_input_dialog->selected_emoji_text();
+        auto emoji_code_point = MUST(String::from_deprecated_string(emoji_input_dialog->selected_emoji_text()));
 
         if (m_cell_value_editor->has_focus_within()) {
             m_cell_value_editor->insert_at_cursor_or_replace_selection(emoji_code_point);
@@ -345,7 +351,7 @@ void SpreadsheetWidget::clipboard_content_did_change(DeprecatedString const& mim
 void SpreadsheetWidget::setup_tabs(Vector<NonnullRefPtr<Sheet>> new_sheets)
 {
     for (auto& sheet : new_sheets) {
-        auto& new_view = m_tab_widget->add_tab<SpreadsheetView>(String::from_deprecated_string(sheet->name()).release_value_but_fixme_should_propagate_errors(), sheet);
+        auto& new_view = m_tab_widget->add_tab<SpreadsheetView>(sheet->name(), sheet);
         new_view.model()->on_cell_data_change = [&](auto& cell, auto& previous_data) {
             undo_stack().push(make<CellsUndoCommand>(cell, previous_data));
             window()->set_modified(true);
@@ -372,13 +378,13 @@ void SpreadsheetWidget::setup_tabs(Vector<NonnullRefPtr<Sheet>> new_sheets)
 
             if (selection.size() == 1) {
                 auto& position = selection.first();
-                m_current_cell_label->set_text(String::from_deprecated_string(position.to_cell_identifier(sheet)).release_value_but_fixme_should_propagate_errors());
+                m_current_cell_label->set_text(position.to_cell_identifier(sheet));
 
                 auto& cell = sheet.ensure(position);
                 m_cell_value_editor->on_change = nullptr;
                 m_cell_value_editor->set_text(cell.source());
                 m_cell_value_editor->on_change = [&] {
-                    auto text = m_cell_value_editor->text();
+                    auto text = MUST(String::from_deprecated_string(m_cell_value_editor->text()));
                     // FIXME: Lines?
                     auto offset = m_cell_value_editor->cursor().column();
                     try_generate_tip_for_input_expression(text, offset);
@@ -411,7 +417,7 @@ void SpreadsheetWidget::setup_tabs(Vector<NonnullRefPtr<Sheet>> new_sheets)
                     if (!sheet_ptr)
                         return;
                     auto& sheet = *sheet_ptr;
-                    auto text = m_cell_value_editor->text();
+                    auto text = MUST(String::from_deprecated_string(m_cell_value_editor->text()));
                     // FIXME: Lines?
                     auto offset = m_cell_value_editor->cursor().column();
                     try_generate_tip_for_input_expression(text, offset);
@@ -467,7 +473,7 @@ void SpreadsheetWidget::try_generate_tip_for_input_expression(StringView source,
     if (text.is_empty()) {
         m_inline_documentation_window->hide();
     } else {
-        m_inline_documentation_label->set_text(String::from_deprecated_string(text).release_value_but_fixme_should_propagate_errors());
+        m_inline_documentation_label->set_text(text);
         m_inline_documentation_window->show();
     }
 }
@@ -564,7 +570,7 @@ void SpreadsheetWidget::save(String const& filename, Core::File& file)
 {
     auto result = m_workbook->write_to_file(filename, file);
     if (result.is_error()) {
-        GUI::MessageBox::show_error(window(), DeprecatedString::formatted("Cannot save file: {}", result.error()));
+        GUI::MessageBox::show_error(window(), MUST(String::formatted("Cannot save file: {}", result.error())));
         return;
     }
     undo_stack().set_current_unmodified();

--- a/Userland/Applications/Spreadsheet/SpreadsheetWidget.h
+++ b/Userland/Applications/Spreadsheet/SpreadsheetWidget.h
@@ -29,7 +29,7 @@ public:
     void add_sheet();
     void add_sheet(NonnullRefPtr<Sheet>&&);
 
-    DeprecatedString const& current_filename() const { return m_workbook->current_filename(); }
+    String const& current_filename() const { return m_workbook->current_filename(); }
     SpreadsheetView* current_view() { return static_cast<SpreadsheetView*>(m_tab_widget->active_widget()); }
     Sheet* current_worksheet_if_available() { return current_view() ? current_view()->sheet_if_available() : nullptr; }
     void update_window_title();

--- a/Userland/Applications/Spreadsheet/Workbook.cpp
+++ b/Userland/Applications/Spreadsheet/Workbook.cpp
@@ -41,7 +41,7 @@ Workbook::Workbook(Vector<NonnullRefPtr<Sheet>>&& sheets, GUI::Window& parent_wi
     m_vm->enable_default_host_import_module_dynamically_hook();
 }
 
-bool Workbook::set_filename(DeprecatedString const& filename)
+bool Workbook::set_filename(String const& filename)
 {
     if (m_current_filename == filename)
         return false;
@@ -50,14 +50,14 @@ bool Workbook::set_filename(DeprecatedString const& filename)
     return true;
 }
 
-ErrorOr<void, DeprecatedString> Workbook::open_file(String const& filename, Core::File& file)
+ErrorOr<void, String> Workbook::open_file(String const& filename, Core::File& file)
 {
     auto mime = Core::guess_mime_type_based_on_filename(filename);
 
     // Make an import dialog, we might need to import it.
     m_sheets = TRY(ImportDialog::make_and_run_for(m_parent_window, mime, filename, file, *this));
 
-    set_filename(filename.to_deprecated_string());
+    set_filename(filename);
 
     return {};
 }
@@ -67,14 +67,14 @@ ErrorOr<void> Workbook::write_to_file(String const& filename, Core::File& stream
     auto mime = Core::guess_mime_type_based_on_filename(filename);
 
     // Make an export dialog, we might need to import it.
-    TRY(ExportDialog::make_and_run_for(mime, stream, filename.to_deprecated_string(), *this));
+    TRY(ExportDialog::make_and_run_for(mime, stream, filename, *this));
 
-    set_filename(filename.to_deprecated_string());
+    set_filename(filename);
     set_dirty(false);
     return {};
 }
 
-ErrorOr<bool, DeprecatedString> Workbook::import_file(String const& filename, Core::File& file)
+ErrorOr<bool, String> Workbook::import_file(String const& filename, Core::File& file)
 {
     auto mime = Core::guess_mime_type_based_on_filename(filename);
 

--- a/Userland/Applications/Spreadsheet/Workbook.h
+++ b/Userland/Applications/Spreadsheet/Workbook.h
@@ -15,13 +15,13 @@ class Workbook {
 public:
     Workbook(Vector<NonnullRefPtr<Sheet>>&& sheets, GUI::Window& parent_window);
 
-    ErrorOr<void, DeprecatedString> open_file(String const& filename, Core::File&);
+    ErrorOr<void, String> open_file(String const& filename, Core::File&);
     ErrorOr<void> write_to_file(String const& filename, Core::File&);
 
-    ErrorOr<bool, DeprecatedString> import_file(String const& filename, Core::File&);
+    ErrorOr<bool, String> import_file(String const& filename, Core::File&);
 
-    DeprecatedString const& current_filename() const { return m_current_filename; }
-    bool set_filename(DeprecatedString const& filename);
+    String const& current_filename() const { return m_current_filename; }
+    bool set_filename(String const& filename);
     bool dirty() { return m_dirty; }
     void set_dirty(bool dirty) { m_dirty = dirty; }
 
@@ -50,7 +50,7 @@ private:
     JS::ExecutionContext m_main_execution_context;
     GUI::Window& m_parent_window;
 
-    DeprecatedString m_current_filename;
+    String m_current_filename;
     bool m_dirty { false };
 };
 

--- a/Userland/Applications/Spreadsheet/Writers/CSV.h
+++ b/Userland/Applications/Spreadsheet/Writers/CSV.h
@@ -17,13 +17,13 @@ public:
     template<typename ContainerType>
     static ErrorOr<void> generate(Stream& output, ContainerType const& data, Vector<StringView> headers = {}, WriterBehavior behaviors = default_behaviors())
     {
-        return XSV<ContainerType>::generate(output, data, { ",", "\"", WriterTraits::Repeat }, move(headers), behaviors);
+        return XSV<ContainerType>::generate(output, data, { ","_string, "\""_string, WriterTraits::Repeat }, move(headers), behaviors);
     }
 
     template<typename ContainerType>
     static ErrorOr<void> generate_preview(Stream& output, ContainerType const& data, Vector<StringView> headers = {}, WriterBehavior behaviors = default_behaviors())
     {
-        return XSV<ContainerType>::generate_preview(output, data, { ",", "\"", WriterTraits::Repeat }, move(headers), behaviors);
+        return XSV<ContainerType>::generate_preview(output, data, { ","_string, "\""_string, WriterTraits::Repeat }, move(headers), behaviors);
     }
 };
 

--- a/Userland/Applications/Spreadsheet/Writers/Test/TestXSVWriter.cpp
+++ b/Userland/Applications/Spreadsheet/Writers/Test/TestXSVWriter.cpp
@@ -52,9 +52,9 @@ TEST_CASE(can_write_with_header)
 
 TEST_CASE(can_write_with_different_behaviors)
 {
-    Vector<Vector<DeprecatedString>> data = {
-        { "Well", "Hello\"", "Friends" },
-        { "We\"ll", "Hello,", "   Friends" },
+    Vector<Vector<String>> data = {
+        { "Well"_string, "Hello\""_string, "Friends"_string },
+        { "We\"ll"_string, "Hello,"_string, "   Friends"_string },
     };
 
     AllocatingMemoryStream stream;

--- a/Userland/Applications/Spreadsheet/Writers/XSV.h
+++ b/Userland/Applications/Spreadsheet/Writers/XSV.h
@@ -6,10 +6,10 @@
 
 #pragma once
 
-#include <AK/DeprecatedString.h>
 #include <AK/GenericLexer.h>
 #include <AK/OwnPtr.h>
 #include <AK/Stream.h>
+#include <AK/String.h>
 #include <AK/StringView.h>
 #include <AK/Types.h>
 #include <AK/Vector.h>
@@ -26,8 +26,8 @@ enum class WriterBehavior : u32 {
 AK_ENUM_BITWISE_OPERATORS(WriterBehavior);
 
 struct WriterTraits {
-    DeprecatedString separator;
-    DeprecatedString quote { "\"" };
+    String separator;
+    String quote { "\""_string };
     enum QuoteEscape {
         Repeat,
         Backslash,
@@ -121,7 +121,7 @@ private:
     template<typename T>
     ErrorOr<void> write_entry(T&& entry)
     {
-        auto string = DeprecatedString::formatted("{}", FormatIfSupported(entry));
+        auto string = TRY(String::formatted("{}", FormatIfSupported(entry)));
 
         auto safe_to_write_normally = !has_flag(m_behaviors, WriterBehavior::QuoteAll)
             && !string.contains('\n')
@@ -129,9 +129,9 @@ private:
 
         if (safe_to_write_normally) {
             if (has_flag(m_behaviors, WriterBehavior::QuoteOnlyInFieldStart))
-                safe_to_write_normally = !string.starts_with(m_traits.quote);
+                safe_to_write_normally = !string.code_points().starts_with(m_traits.quote.code_points());
             else
-                safe_to_write_normally = !string.contains(m_traits.quote);
+                safe_to_write_normally = !string.contains(m_traits.quote.bytes_as_string_view());
         }
 
         if (safe_to_write_normally) {
@@ -144,7 +144,7 @@ private:
 
         GenericLexer lexer(string);
         while (!lexer.is_eof()) {
-            if (lexer.consume_specific(m_traits.quote.view())) {
+            if (lexer.consume_specific(m_traits.quote)) {
                 switch (m_traits.quote_escape) {
                 case WriterTraits::Repeat:
                     TRY(m_output.write_until_depleted(m_traits.quote.bytes()));


### PR DESCRIPTION
As per #20405, this ignores most String OOMs and assumes (as before) that all string data inside Spreadsheet is UTF-8, crashing the program otherwise.