### PR TITLE
Display Ipv6 addresses in System Monitor

### DIFF
--- a/Userland/Applications/SystemMonitor/NetworkStatisticsWidget.cpp
+++ b/Userland/Applications/SystemMonitor/NetworkStatisticsWidget.cpp
@@ -65,6 +65,10 @@ NetworkStatisticsWidget::NetworkStatisticsWidget()
             [](JsonObject const& object) -> ByteString {
                 return object.get_byte_string("ipv4_address"sv).value_or(""sv);
             });
+        net_adapters_fields.empend("IPv6"_string, Gfx::TextAlignment::CenterLeft,
+            [](JsonObject const& object) -> ByteString {
+                return object.get_byte_string("ipv6_address"sv).value_or(""sv);
+            });
         net_adapters_fields.empend("packets_in", "Pkt In"_string, Gfx::TextAlignment::CenterRight);
         net_adapters_fields.empend("packets_out", "Pkt Out"_string, Gfx::TextAlignment::CenterRight);
         net_adapters_fields.empend("bytes_in", "Bytes In"_string, Gfx::TextAlignment::CenterRight);

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1701253981,
-        "narHash": "sha256-ztaDIyZ7HrTAfEEUt9AtTDNoCYxUdSd6NrRHaYOIxtk=",
+        "lastModified": 1724479785,
+        "narHash": "sha256-pP3Azj5d6M5nmG68Fu4JqZmdGt4S4vqI5f8te+E/FTw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e92039b55bcd58469325ded85d4f58dd5a4eaf58",
+        "rev": "d0e1602ddde669d5beb01aec49d71a51937ed7be",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Note: this also updates the Nix flake lock so qemu runs again on my nixos-unstable system